### PR TITLE
dev-MUSE_NFM

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: SimSpin
 Type: Package
 Title: SimSpin - A package for the kinematic analysis of galaxy simulations
-Version: 2.3.0
+Version: 2.3.1
 Author: Katherine Harborne
 Maintainer: <katherine.harborne@icrar.org>
 Description: The purpose of this package is to provide a set of tools to "observe" simulations of galaxies as if you were an observer using an integral field unit (IFU). The galaxy model can be observed at a chosen inclination and an IFU observation can be produced in a selection of different spatial shapes (square, circular, and hexagonal) to account for the variety of CCD arrangements used by current telescopes. This data cube can be used to calculate the value an observer would measure for the spin parameter compared to the value that is measured directly from the simulation.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,8 @@
-# SimSpin v2.3.0 News
+# SimSpin v2.3.1 News
 
 ### Author: Kate Harborne
 
-### Last edit: 24/05/22
+### Last edit: 20/06/22
 
 Below is a table containing a summary of all changes made to SimSpin, since the date this file was created on 26/08/2021.
 
@@ -43,6 +43,7 @@ Below is a table containing a summary of all changes made to SimSpin, since the 
 | 24/05/22 	| *Medium change* Update to `build_datacube()` -                                                                                                                                                                                                                                                                                         	| 2.2.0   	|                                          	|
 |          	| (1) `method` of observation is now specified directly in the `build_datacube` function - rather than within `telescope()`. This means that a given telescope can be specified once, while the type of cube being built can be modified. This is more logical as an inbuilt telescope type now only needs to be specified by "type".    	|         	|                                          	|
 |          	| (2) `output_location` has modified behaviour to allow a user to just specify an output PATH (rather than having to auto-save FITS to the same directory as the input SimSpin file). Documentation updated to reflect this change.                                                                                                      	|         	|                                          	|
-| 13/06/22 	| *Medium change* Update to `build_datacube()` and `make_simspin_file()` -                                                                                                                                                                                                                                                               	| 2.3.0   	|                                          	|
+| 13/06/22 	| *Medium change* Update to `build_datacube()` and `make_simspin_file()` -                                                                                                                                                                                                                                                               	| 2.3.0   	| 62afd85ecd11bfdfb91832d8de49c9abe40eca9f 	|
 |          	| (1) Output SimSpin files now include an additional `header` element describing the code version with which the file was made, the properties and name of the template used to derive particle spectra, and the type of input simulation.                                                                                               	|         	|                                          	|
 |          	| (2) The LSF treatment in `build_datacube` has been modified to account for the fact that the underlying spectral templates have a LSF themselves, and it is only necessary to convolve these up by the mean-square difference between the teescope LSF and the input template.                                                         	|         	|                                          	|
+| 20/06/22 	| *Minor bugfix*. Updating `telescope` class to allow two modes of spatial resolution of the MUSE telescope. This addresses Issue #43. Similarly, we've added the requirement for the MUSE field-of-view to be less than 60" and for MaNGA fov to be from the specific selection of options (12, 17, 22, 27, 32).                        	| 2.3.1   	|                                          	|

--- a/R/telescope.R
+++ b/R/telescope.R
@@ -44,8 +44,8 @@
 #'telescope = telescope(type="SAMI")
 #'
 
-telescope = function(type="IFU", fov=15, aperture_shape="circular", wave_range=c(3700,5700),
-                     wave_centre, wave_res=1.04, spatial_res=0.5, filter="r", lsf_fwhm=2.65,
+telescope = function(type="IFU", fov, aperture_shape="circular", wave_range=c(3700,5700),
+                     wave_centre, wave_res=1.04, spatial_res, filter="r", lsf_fwhm=2.65,
                      signal_to_noise = 10, method){
 
   if (!missing(method)){
@@ -112,7 +112,24 @@ telescope = function(type="IFU", fov=15, aperture_shape="circular", wave_range=c
     }
 
     if(stringr::str_to_upper(type)  == "MANGA"){
+
       spatial_res = 0.5
+
+      if (missing(fov)){
+        fov = 12
+      } else {
+        fov_pos = c(12, 17, 22, 27, 32)
+        if (!fov %in% fov_pos){
+          suggested_fov = fov_pos[which((fov_pos - fov) > 0)[1]]
+          warning(paste0(">>> WARNING! >>> \n
+                         `fov` specified is not an option for telescope type `MaNGA`. \n
+                         `fov` options include 12, 17, 22, 27, or 32. \n
+                         Setting 'fov' to the nearest available option. \n
+                         fov = ", suggested_fov))
+          fov = suggested_fov
+        } # catching any inputs that are not suitable for MaNGA telescope
+      }
+
       output = list(type            = "MaNGA",
                     fov             = fov,
                     aperture_shape  = "hexagonal",
@@ -127,7 +144,35 @@ telescope = function(type="IFU", fov=15, aperture_shape="circular", wave_range=c
     }
 
     if(stringr::str_to_upper(type)  == "MUSE"){
-      spatial_res = 0.2
+
+      if (missing(spatial_res)){
+        spatial_res = 0.2
+      } else {
+        pos_spatial_res = c(0.025, 0.2)
+        if (!spatial_res %in% pos_spatial_res){
+          spatial_res = 0.2
+          warning(">>> WARNING! >>> \n
+                  `spatial_res` specified is not an option for telescope type `MUSE`. \n
+                  `spatial_res` options include 0.025 (NFM) or 0.2 (WFM). \n
+                  Setting `spatial_res` to the default. \n
+                  spatial_res = 0.2 ")
+
+        }
+      }
+
+      if (missing(fov)){
+        fov = 5
+      } else {
+        if (fov > 60){
+          warning(paste0(">>> WARNING! >>> \n
+                         `fov` specified is not an option for telescope type 'MUSE'. \n
+                         `fov` options must be less than 60. \n
+                         Setting `fov` to the nearest available option. \n
+                         fov = 60"))
+          fov = 60
+        } # catching any inputs that are not suitable for MaNGA telescope
+      }
+
       output = list(type            = "MUSE",
                     fov             = fov,
                     aperture_shape  = "square",
@@ -178,6 +223,9 @@ telescope = function(type="IFU", fov=15, aperture_shape="circular", wave_range=c
 
     if(stringr::str_to_upper(type)  == "IFU"){
 
+      if (missing(fov)){fov = 15} # setting to the default parameter expected
+      if (missing(spatial_res)){spatial_res = 0.5}
+
       output = list(type            = "IFU",
                     fov             = fov,
                     aperture_shape  = stringr::str_to_lower(aperture_shape),
@@ -190,7 +238,9 @@ telescope = function(type="IFU", fov=15, aperture_shape="circular", wave_range=c
                     signal_to_noise = signal_to_noise,
                     sbin            = floor(fov / spatial_res))
     }
+
   } else {
+
     if(stringr::str_to_upper(type)  == "SAMI"){
       fov = 15
       spatial_res = 0.5
@@ -209,7 +259,24 @@ telescope = function(type="IFU", fov=15, aperture_shape="circular", wave_range=c
     }
 
     if(stringr::str_to_upper(type)  == "MANGA"){
+
       spatial_res = 0.5
+
+      if (missing(fov)){
+        fov = 12
+      } else {
+        fov_pos = c(12, 17, 22, 27, 32)
+        if (!fov %in% fov_pos){
+          suggested_fov = fov_pos[which((fov_pos - fov) > 0)[1]]
+          warning(paste0(">>> WARNING! >>> \n
+                         `fov` specified is not an option for telescope type `MaNGA`. \n
+                         `fov` options include 12, 17, 22, 27, or 32. \n
+                         Setting `fov` to the nearest available option. \n
+                         fov = ", suggested_fov))
+          fov = suggested_fov
+        } # catching any inputs that are not suitable for MaNGA telescope
+      }
+
       output = list(type            = "MaNGA",
                     method          = method,
                     fov             = fov,
@@ -225,7 +292,35 @@ telescope = function(type="IFU", fov=15, aperture_shape="circular", wave_range=c
     }
 
     if(stringr::str_to_upper(type)  == "MUSE"){
-      spatial_res = 0.2
+
+      if (missing(spatial_res)){
+        spatial_res = 0.2
+      } else {
+        pos_spatial_res = c(0.025, 0.2)
+        if (!spatial_res %in% pos_spatial_res){
+          spatial_res = 0.2
+          warning(">>> WARNING! >>> \n
+                  `spatial_res` specified is not an option for telescope type `MUSE`. \n
+                  `spatial_res` options include 0.025 (NFM) or 0.2 (WFM). \n
+                  Setting 'spatial_res' to the default. \n
+                  spatial_res = 0.2 ")
+
+        }
+      }
+
+      if (missing(fov)){
+          fov = 5
+        } else {
+          if (fov > 60){
+            warning(paste0(">>> WARNING! >>> \n
+                         `fov` specified is not an option for telescope type `MUSE`. \n
+                         `fov` options must be less than 60. \n
+                         Setting `fov` to the nearest available option. \n
+                         fov = 60"))
+            fov = 60
+          } # catching any inputs that are not suitable for MaNGA telescope
+        }
+
       output = list(type            = "MUSE",
                     method          = method,
                     fov             = fov,
@@ -278,6 +373,9 @@ telescope = function(type="IFU", fov=15, aperture_shape="circular", wave_range=c
     }
 
     if(stringr::str_to_upper(type)  == "IFU"){
+
+      if (missing(fov)){fov = 15} # setting to the default parameter expected
+      if (missing(spatial_res)){spatial_res = 0.5}
 
       output = list(type            = "IFU",
                     fov             = fov,

--- a/R/telescope.R
+++ b/R/telescope.R
@@ -120,7 +120,11 @@ telescope = function(type="IFU", fov, aperture_shape="circular", wave_range=c(37
       } else {
         fov_pos = c(12, 17, 22, 27, 32)
         if (!fov %in% fov_pos){
-          suggested_fov = fov_pos[which((fov_pos - fov) > 0)[1]]
+          if (fov > max(fov_pos)){
+            suggested_fov = max(fov_pos)
+          } else {
+            suggested_fov = fov_pos[which((fov_pos - fov) > 0)[1]]
+          }
           warning(paste0(">>> WARNING! >>> \n
                          `fov` specified is not an option for telescope type `MaNGA`. \n
                          `fov` options include 12, 17, 22, 27, or 32. \n

--- a/man/telescope.Rd
+++ b/man/telescope.Rd
@@ -6,12 +6,12 @@
 \usage{
 telescope(
   type = "IFU",
-  fov = 15,
+  fov,
   aperture_shape = "circular",
   wave_range = c(3700, 5700),
   wave_centre,
   wave_res = 1.04,
-  spatial_res = 0.5,
+  spatial_res,
   filter = "r",
   lsf_fwhm = 2.65,
   signal_to_noise = 10,

--- a/tests/testthat/test_observations.R
+++ b/tests/testthat/test_observations.R
@@ -18,10 +18,41 @@ test_that("Initial run of telescope() function with default types - SAMI.", {
 
 test_that("Initial run of telescope() function with default types - MaNGA", {
   expect_length(telescope(type="MaNGA"), telescope_length)
+  expect_warning(telescope(type="MaNGA", fov = 15))
+
+  manga = suppressWarnings(telescope(type="MaNGA", fov = 15))
+  expect_true(manga$fov == 17)
+  expect_length(manga, telescope_length)
+  remove(manga)
 })
 
-test_that("Initial run of telescope() function with default types - MaNGA", {
+test_that("Initial run of telescope() function with default types - MUSE", {
   expect_length(telescope(type="MUSE"), telescope_length)
+  expect_length(telescope(type="MUSE", fov = 16), telescope_length)
+  expect_length(telescope(type="MUSE", spatial_res = 0.2), telescope_length)
+  expect_length(telescope(type="MUSE", spatial_res = 0.025), telescope_length)
+  expect_warning(telescope(type="MUSE", spatial_res = 0.1))
+  expect_warning(telescope(type="MUSE", fov = 61))
+
+  # checking that fov is automatically rounded down to 60
+  muse60 = suppressWarnings(telescope(type="MUSE", fov = 61))
+  expect_true(muse60$fov == 60)
+  expect_length(muse60, telescope_length)
+  remove(muse60)
+
+  # checking that spatial res is automatically set to 0.2
+  muse02 = suppressWarnings(telescope(type="MUSE", spatial_res = 0.1))
+  expect_true(muse02$spatial_res == 0.2)
+  expect_length(muse02, telescope_length)
+  remove(muse02)
+
+  # checking that spatial res can be set to NFM
+  museNFM = telescope(type="MUSE", spatial_res = 0.025)
+  expect_true(museNFM$spatial_res == 0.025)
+  expect_length(museNFM, telescope_length)
+  remove(museNFM)
+
+
 })
 
 test_that("Initial run of telescope() function with default types - Hector", {
@@ -103,7 +134,10 @@ test_that("telescope() issues warning when method parameter is given.", {
 
   expect_warning(telescope(type="SAMI", method = "spectral"))
   expect_warning(telescope(type="MaNGA", method = "spectral"))
+  expect_warning(telescope(type="MaNGA", method = "spectral", fov = 15))
   expect_warning(telescope(type="MUSE", method = "spectral"))
+  expect_warning(telescope(type="MUSE", method = "spectral", fov = 61))
+  expect_warning(telescope(type="MUSE", method = "spectral", spatial_res = 0.1))
   expect_warning(telescope(type="Hector", method = "spectral"))
   expect_warning(telescope(type="CALIFA", method = "spectral"))
 })

--- a/tests/testthat/test_observations.R
+++ b/tests/testthat/test_observations.R
@@ -20,10 +20,15 @@ test_that("Initial run of telescope() function with default types - MaNGA", {
   expect_length(telescope(type="MaNGA"), telescope_length)
   expect_warning(telescope(type="MaNGA", fov = 15))
 
-  manga = suppressWarnings(telescope(type="MaNGA", fov = 15))
-  expect_true(manga$fov == 17)
-  expect_length(manga, telescope_length)
-  remove(manga)
+  manga15 = suppressWarnings(telescope(type="MaNGA", fov = 15))
+  expect_true(manga15$fov == 17)
+  expect_length(manga15, telescope_length)
+  remove(manga15)
+
+  manga33 = suppressWarnings(telescope(type="MaNGA", fov = 33))
+  expect_true(manga33$fov == 32)
+  expect_length(manga33, telescope_length)
+  remove(manga33)
 })
 
 test_that("Initial run of telescope() function with default types - MUSE", {


### PR DESCRIPTION
Updating the `telescope` function to address the issues raised in #43. The following changes have been made:

- For `type = "MUSE"`, two options for `spatial_res` now exist (0.2 and 0.025 to allow for MUSE wide field mode and near field mode respectively). If an option is selected that is not one of these two, the code will issue a warning and default to the WFM as this is computationally quicker. 
- For `type = "MUSE"`, the `fov` option now has a hard limit at 60" (i.e. the maximum field-of-view of MUSE). If a value larger than 60 is input, the code will issue a warning and default to this maximum value. Below 60", any value can be picked. 
- For `type = "MaNGA"`, the `fov` option now has specific options (rather than free for the user to select). Options include 12, 17, 22, 27 and 32. If an option is selected outside of these options, the next closest option is selected that is larger than the list of possible. If a fov larger than 32 is requested, the code will round down to the maximum. A warning will be issued in these cases. 
