### PR TITLE
dev-centre_bug

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: SimSpin
 Type: Package
 Title: SimSpin - A package for the kinematic analysis of galaxy simulations
-Version: 2.3.3
+Version: 2.3.4
 Author: Katherine Harborne
 Maintainer: <katherine.harborne@icrar.org>
 Description: The purpose of this package is to provide a set of tools to "observe" simulations of galaxies as if you were an observer using an integral field unit (IFU). The galaxy model can be observed at a chosen inclination and an IFU observation can be produced in a selection of different spatial shapes (square, circular, and hexagonal) to account for the variety of CCD arrangements used by current telescopes. This data cube can be used to calculate the value an observer would measure for the spin parameter compared to the value that is measured directly from the simulation.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,8 @@
-# SimSpin v2.3.3 News
+# SimSpin v2.3.4 News
 
 ### Author: Kate Harborne
 
-### Last edit: 01/07/22
+### Last edit: 12/07/22
 
 Below is a table containing a summary of all changes made to SimSpin, since the date this file was created on 26/08/2021.
 
@@ -48,4 +48,5 @@ Below is a table containing a summary of all changes made to SimSpin, since the 
 |          	| (2) The LSF treatment in `build_datacube` has been modified to account for the fact that the underlying spectral templates have a LSF themselves, and it is only necessary to convolve these up by the mean-square difference between the teescope LSF and the input template.                                                                                                                                       	|         	|                                          	|
 | 20/06/22 	| *Minor bugfix*. Updating `telescope` class to allow two modes of spatial resolution of the MUSE telescope. This addresses Issue #43. Similarly, we've added the requirement for the MUSE field-of-view to be less than 60" and for MaNGA fov to be from the specific selection of options (12, 17, 22, 27, 32).                                                                                                      	| 2.3.1   	| dbba3af4c926e9c8c9e2a650d22dee2bf0d0f837 	|
 | 27/06/22 	| *Minor bugfix*. Updating `build_datacube` to make sure backwards compatibility. If a SimSpin file from versions preceading v2.3.0 are used with the function, it now assumes a header based on the wavelength information. This will also issue a warning to explain and encourage the user to remake their SimSpin file. Errors if custom template is used with no details of LSF or wave_res. Addresses Issue #45. 	| 2.3.2   	| cfdfdbf304df0243efd608539d5087e09a223525 	|
-| 01/07/22 	| *Minor bugfix*. Adding support for ingestion of HorizonAGN data (i.e. AMR code data support). Updates to `make_simspin_file`, `utilities` and tests were implemented. Addresses Issue #42. Also, made observational images consistent with raw images (removing NAs and replacing with 0's).                                                                                                                         	| 2.3.3   	|                                          	|
+| 01/07/22 	| *Minor bugfix*. Adding support for ingestion of HorizonAGN data (i.e. AMR code data support). Updates to `make_simspin_file`, `utilities` and tests were implemented. Addresses Issue #42. Also, made observational images consistent with raw images (removing NAs and replacing with 0's).                                                                                                                         	| 2.3.3   	| e4ca02bf3ab482a0fd9a1abd6e2442c0e4a41da4 	|
+| 12/07/22 	| *Minor bugfix*. Update to `build_datacube`. Returning a meaningful error if the requested `centre` position is outside the range of the provided input file. Tests added to ensure behaviour now works as expected.                                                                                                                                                                                                  	| 2.3.4   	|                                          	|

--- a/R/make_simspin_file.R
+++ b/R/make_simspin_file.R
@@ -33,11 +33,13 @@
 #'@param centre If simulation file contains all particles cutout from a box
 #' (rather than just particles from a single galaxy), you can specify the point
 #' around which the view should be centred. Numeric length = 3. Default is NA,
-#' in which case the system is centred around the median position.
+#' in which case the system is centred around the median position. Specified in
+#' units of kpc.
 #'@param half_mass If simulation file contains all particles cutout from a box
 #' (rather than just particles from a single galaxy), you can the half-mass
 #' value at which the alignment function is run. Numeric length = 1. Default is
-#' NA, in which case half the total mass of the suplied simulation data is used.
+#' NA, in which case half the total mass of the supplied simulation data is
+#' used. Specified in units of solar mass.
 #'@param sph_spawn_n Numeric describing the number of gas particles with which
 #' to sample the SPH smoothing length. Default is 1, which will not spawn
 #' additional gas particles. Increasing this value increases the number of

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -579,26 +579,40 @@ globalVariables(c(".N", ":=", "Age", "Carbon", "CellSize", "Density", "Hydrogen"
     stellar_data = galaxy_data$star_part
     gas_data = galaxy_data$gas_part
 
-    stellar_data$x = stellar_data$x - centre[1]
-    stellar_data$y = stellar_data$y - centre[2]
-    stellar_data$z = stellar_data$z - centre[3]
-    star_r2 = stellar_data$x^2 + stellar_data$y^2 + stellar_data$z^2
-    star_vcen = c(median(stellar_data$vx[star_r2 < 100]), # using the median velocities within
-                  median(stellar_data$vy[star_r2 < 100]), #  10kpc of the galaxy centre to define
-                  median(stellar_data$vz[star_r2 < 100])) #  the central velocity
-    stellar_data$vx = stellar_data$vx - star_vcen[1]
-    stellar_data$vy = stellar_data$vy - star_vcen[2]
-    stellar_data$vz = stellar_data$vz - star_vcen[3]
+    # check that provided centre falls within the range of values within the input file
+    check_bounds = (centre[1] >= min(stellar_data$x) & centre[1] <= max(stellar_data$x) &
+                    centre[2] >= min(stellar_data$y) & centre[2] <= max(stellar_data$y) &
+                    centre[3] >= min(stellar_data$z) & centre[3] <= max(stellar_data$z))
 
-    gas_data$x = gas_data$x - centre[1]
-    gas_data$y = gas_data$y - centre[2]
-    gas_data$z = gas_data$z - centre[3]
-    gas_data$vx = gas_data$vx - star_vcen[1]
-    gas_data$vy = gas_data$vy - star_vcen[2]
-    gas_data$vz = gas_data$vz - star_vcen[3]
+    if (check_bounds){
+      stellar_data$x = stellar_data$x - centre[1]
+      stellar_data$y = stellar_data$y - centre[2]
+      stellar_data$z = stellar_data$z - centre[3]
+      star_r2 = stellar_data$x^2 + stellar_data$y^2 + stellar_data$z^2
+      star_vcen = c(median(stellar_data$vx[star_r2 < 100]), # using the median velocities within
+                    median(stellar_data$vy[star_r2 < 100]), #  10kpc of the galaxy centre to define
+                    median(stellar_data$vz[star_r2 < 100])) #  the central velocity
+      stellar_data$vx = stellar_data$vx - star_vcen[1]
+      stellar_data$vy = stellar_data$vy - star_vcen[2]
+      stellar_data$vz = stellar_data$vz - star_vcen[3]
 
-    galaxy_data$star_part = stellar_data
-    galaxy_data$gas_part = gas_data
+      gas_data$x = gas_data$x - centre[1]
+      gas_data$y = gas_data$y - centre[2]
+      gas_data$z = gas_data$z - centre[3]
+      gas_data$vx = gas_data$vx - star_vcen[1]
+      gas_data$vy = gas_data$vy - star_vcen[2]
+      gas_data$vz = gas_data$vz - star_vcen[3]
+
+      galaxy_data$star_part = stellar_data
+      galaxy_data$gas_part = gas_data
+    } else {
+      stop(paste0("Error: Requested centre is outside the bounds of the region within the input file. \n
+                  Please re-submit with centre specified, c(x,y,z): \n ",
+                  min(stellar_data$x), " <= x <= ", max(stellar_data$x), "\n ",
+                  min(stellar_data$y), " <= y <= ", max(stellar_data$y), "\n ",
+                  min(stellar_data$z), " <= z <= ", max(stellar_data$z), "\n "))
+    }
+
 
   } else if (!is.null(galaxy_data$star_part)){
     stellar_data = cen_galaxy(galaxy_data$star_part) # centering and computing medians for stellar particles

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 <p>&nbsp;</p>
 
-SimSpin v2.3.2 - A package for producing mock observations of particle simulations
+SimSpin v2.3.4 - A package for producing mock observations of particle simulations
 
 The purpose of the SimSpin R-package is to take a particle simulation of a galaxy and produce a spectral data cube in the style of a specified Integral Field Spectroscopy (IFS) instrument.
 

--- a/man/make_simspin_file.Rd
+++ b/man/make_simspin_file.Rd
@@ -52,12 +52,14 @@ a new file will be written over the old one.}
 \item{centre}{If simulation file contains all particles cutout from a box
 (rather than just particles from a single galaxy), you can specify the point
 around which the view should be centred. Numeric length = 3. Default is NA,
-in which case the system is centred around the median position.}
+in which case the system is centred around the median position. Specified in
+units of kpc.}
 
 \item{half_mass}{If simulation file contains all particles cutout from a box
 (rather than just particles from a single galaxy), you can the half-mass
 value at which the alignment function is run. Numeric length = 1. Default is
-NA, in which case half the total mass of the suplied simulation data is used.}
+NA, in which case half the total mass of the supplied simulation data is
+used. Specified in units of solar mass.}
 
 \item{sph_spawn_n}{Numeric describing the number of gas particles with which
 to sample the SPH smoothing length. Default is 1, which will not spawn

--- a/tests/testthat/test_make_simspin_file.R
+++ b/tests/testthat/test_make_simspin_file.R
@@ -231,8 +231,8 @@ unlink(c(paste(temp_loc, "/gadget_test", sep=""), paste(temp_loc, "/hdf5_test", 
 test_that("Objects are centered correctly based on the specified central coordinates", {
   expect_error(make_simspin_file(filename = ss_horizon, template = "EMILES", write_to_file = F, centre = c(0,0,0)))
 
-  centre_left  = make_simspin_file(filename = ss_horizon, template = "BC03lr", write_to_file = F, centre = c(12325,72177.97,32388.04))
-  centre_right = make_simspin_file(filename = ss_horizon, template = "BC03lr", write_to_file = F, centre = c(12335,72177.97,32388.04))
+  centre_right = make_simspin_file(filename = ss_horizon, template = "BC03lr", write_to_file = F, centre = c(12328,72177.97,32388.04))
+  centre_left  = make_simspin_file(filename = ss_horizon, template = "BC03lr", write_to_file = F, centre = c(12332,72177.97,32388.04))
 
   # Checking values exist in fields for LEFT
   expect_true(all(!is.na(centre_left$star_part$x)))
@@ -292,7 +292,13 @@ test_that("Objects are centered correctly based on the specified central coordin
   expect_true(all(!is.na(centre_right$gas_part$Oxygen)))
   expect_true(all(!is.na(centre_right$gas_part$Hydrogen)))
 
-  # Expect that the centre of the left is to the left of the centre of the right!
+  galaxy_data = tryCatch(expr = {.read_gadget(ss_horizon)},
+                         error = function(e){.read_hdf5(ss_horizon, cores=1)})
+  galaxy_data_right = .centre_galaxy(galaxy_data, centre=c(12328,72177.97,32388.04)) # centering the galaxy based on stellar particles
+  galaxy_data_left = .centre_galaxy(galaxy_data, centre=c(12332,72177.97,32388.04))
+
   expect_true(median(centre_left$star_part$x) < median(centre_right$star_part$x))
+
+
 })
 

--- a/tests/testthat/test_make_simspin_file.R
+++ b/tests/testthat/test_make_simspin_file.R
@@ -29,7 +29,7 @@ test_that("Initial run of each simulation type - HDF5", {
 })
 
 test_that("Initial run of each simulation type - EAGLE", {
-  expect_null(make_simspin_file(ss_eagle, output = paste(temp_loc, "/eagle_test", sep=""), centre = c(0.01,0.02,0.01), half_mass = 1483809589))
+  expect_null(make_simspin_file(ss_eagle, output = paste(temp_loc, "/eagle_test", sep=""), centre = c(18318,61583,38667), half_mass = 1483809589))
   expect_length(readRDS(paste(temp_loc, "/eagle_test", sep="")), ss_file_length)
   expect_true(length(readRDS(paste(temp_loc, "/eagle_test", sep=""))$gas_part) == 16)
 })

--- a/tests/testthat/test_make_simspin_file.R
+++ b/tests/testthat/test_make_simspin_file.R
@@ -297,7 +297,8 @@ test_that("Objects are centered correctly based on the specified central coordin
   galaxy_data_right = .centre_galaxy(galaxy_data, centre=c(12328,72177.97,32388.04)) # centering the galaxy based on stellar particles
   galaxy_data_left = .centre_galaxy(galaxy_data, centre=c(12332,72177.97,32388.04))
 
-  expect_true(median(centre_left$star_part$x) < median(centre_right$star_part$x))
+  # Need to run without align! This causes variations in the end output.
+  expect_true(median(galaxy_data_left$star_part$x) < median(galaxy_data_right$star_part$x))
 
 
 })

--- a/tests/testthat/test_make_simspin_file.R
+++ b/tests/testthat/test_make_simspin_file.R
@@ -223,7 +223,76 @@ test_that("Testing that the header data works as expected", {
   remove(gadget, hdf5, eagle, magneticum, horizon)
  })
 
-
 unlink(c(paste(temp_loc, "/gadget_test", sep=""), paste(temp_loc, "/hdf5_test", sep=""),
          paste(temp_loc, "/eagle_test", sep=""), paste(temp_loc, "/magneticum_test", sep=""),
          paste(temp_loc, "/horizon_test", sep="")))
+
+# Testing that the centre parameter works as expected ------------
+test_that("Objects are centered correctly based on the specified central coordinates", {
+  expect_error(make_simspin_file(filename = ss_horizon, template = "EMILES", write_to_file = F, centre = c(0,0,0)))
+
+  centre_left  = make_simspin_file(filename = ss_horizon, template = "BC03lr", write_to_file = F, centre = c(12325,72177.97,32388.04))
+  centre_right = make_simspin_file(filename = ss_horizon, template = "BC03lr", write_to_file = F, centre = c(12335,72177.97,32388.04))
+
+  # Checking values exist in fields for LEFT
+  expect_true(all(!is.na(centre_left$star_part$x)))
+  expect_true(all(!is.na(centre_left$star_part$y)))
+  expect_true(all(!is.na(centre_left$star_part$z)))
+  expect_true(all(!is.na(centre_left$star_part$vx)))
+  expect_true(all(!is.na(centre_left$star_part$vy)))
+  expect_true(all(!is.na(centre_left$star_part$vz)))
+  expect_true(all(!is.na(centre_left$star_part$Mass)))
+  expect_true(all(!is.na(centre_left$star_part$sed_id)))
+  expect_true(all(!is.na(centre_left$star_part$Metallicity)))
+  expect_true(all(!is.na(centre_left$star_part$Age)))
+  expect_true(all(!is.na(centre_left$star_part$Initial_Mass)))
+
+  expect_true(all(!is.na(centre_left$gas_part$x)))
+  expect_true(all(!is.na(centre_left$gas_part$y)))
+  expect_true(all(!is.na(centre_left$gas_part$z)))
+  expect_true(all(!is.na(centre_left$gas_part$vx)))
+  expect_true(all(!is.na(centre_left$gas_part$vy)))
+  expect_true(all(!is.na(centre_left$gas_part$vz)))
+  expect_true(all(!is.na(centre_left$gas_part$Mass)))
+  expect_true(all(!is.na(centre_left$gas_part$SFR)))
+  expect_true(all(!is.na(centre_left$gas_part$Density)))
+  expect_true(all(!is.na(centre_left$gas_part$Temperature)))
+  expect_true(all(!is.na(centre_left$gas_part$CellSize)))
+  expect_true(all(!is.na(centre_left$gas_part$Metallicity)))
+  expect_true(all(!is.na(centre_left$gas_part$Carbon)))
+  expect_true(all(!is.na(centre_left$gas_part$Oxygen)))
+  expect_true(all(!is.na(centre_left$gas_part$Hydrogen)))
+
+  # Checking values exist in fields for RIGHT
+  expect_true(all(!is.na(centre_right$star_part$x)))
+  expect_true(all(!is.na(centre_right$star_part$y)))
+  expect_true(all(!is.na(centre_right$star_part$z)))
+  expect_true(all(!is.na(centre_right$star_part$vx)))
+  expect_true(all(!is.na(centre_right$star_part$vy)))
+  expect_true(all(!is.na(centre_right$star_part$vz)))
+  expect_true(all(!is.na(centre_right$star_part$Mass)))
+  expect_true(all(!is.na(centre_right$star_part$sed_id)))
+  expect_true(all(!is.na(centre_right$star_part$Metallicity)))
+  expect_true(all(!is.na(centre_right$star_part$Age)))
+  expect_true(all(!is.na(centre_right$star_part$Initial_Mass)))
+
+  expect_true(all(!is.na(centre_right$gas_part$x)))
+  expect_true(all(!is.na(centre_right$gas_part$y)))
+  expect_true(all(!is.na(centre_right$gas_part$z)))
+  expect_true(all(!is.na(centre_right$gas_part$vx)))
+  expect_true(all(!is.na(centre_right$gas_part$vy)))
+  expect_true(all(!is.na(centre_right$gas_part$vz)))
+  expect_true(all(!is.na(centre_right$gas_part$Mass)))
+  expect_true(all(!is.na(centre_right$gas_part$SFR)))
+  expect_true(all(!is.na(centre_right$gas_part$Density)))
+  expect_true(all(!is.na(centre_right$gas_part$Temperature)))
+  expect_true(all(!is.na(centre_right$gas_part$CellSize)))
+  expect_true(all(!is.na(centre_right$gas_part$Metallicity)))
+  expect_true(all(!is.na(centre_right$gas_part$Carbon)))
+  expect_true(all(!is.na(centre_right$gas_part$Oxygen)))
+  expect_true(all(!is.na(centre_right$gas_part$Hydrogen)))
+
+  # Expect that the centre of the left is to the left of the centre of the right!
+  expect_true(median(centre_left$star_part$x) < median(centre_right$star_part$x))
+})
+


### PR DESCRIPTION
Adding code to catch when a requested galaxy `centre` is supplied to make_simspin_file that lies outside the region covered by the particles within the input simulation file. 

Tests added to check: 
- Error is caught and code issues a meaningful warning to the user.
- `centre` behaves as expected (i.e. if you put in a centre to the left, it centres around a different point.)