### PR TITLE
dev-OBTABLE_bugfix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: SimSpin
 Type: Package
 Title: SimSpin - A package for the kinematic analysis of galaxy simulations
-Version: 2.3.12
+Version: 2.3.13
 Author: Katherine Harborne
 Maintainer: <katherine.harborne@icrar.org>
 Description: The purpose of this package is to provide a set of tools to "observe" simulations of galaxies as if you were an observer using an integral field unit (IFU). The galaxy model can be observed at a chosen inclination and an IFU observation can be produced in a selection of different spatial shapes (square, circular, and hexagonal) to account for the variety of CCD arrangements used by current telescopes. This data cube can be used to calculate the value an observer would measure for the spin parameter compared to the value that is measured directly from the simulation.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,8 @@
-# SimSpin v2.3.12 News
+# SimSpin v2.3.13 News
 
 ### Author: Kate Harborne
 
-### Last edit: 29/07/22
+### Last edit: 01/08/22
 
 Below is a table containing a summary of all changes made to SimSpin, since the date this file was created on 26/08/2021.
 
@@ -18,7 +18,8 @@ All changes are noted in the changelog table below.
 
 | Date     | Summary of change                                                                                                                                                                                                                                                                                                                                                                                                    | Version | Commit                                   |
 |----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|------------------------------------------|
-| 29/07/22 	| *Minor bugfix*. Addressing Issue #59. Making sure any NA values within the `observation` list are re-written as "None" in characters before writing to FITS.                                                                                                                                                                                                                                                         	| 2.3.12  	|                                          	|
+| 01/08/22 	| *Minor bugfix*. Addressing Issue #59 (which was not actually fixed in previous attempt!). Making sure long entries (i.e. wave_seq, vbin_seq or sbin_seq) are never too long to be written to a FITS table. Change to range (i.e. min and max) to remove this as an issue.                                                                                                                                            	| 2.3.13  	|                                          	|
+| 29/07/22 	| *Minor bugfix*. Addressing Issue #59. Making sure any NA values within the `observation` list are re-written as "None" in characters before writing to FITS.                                                                                                                                                                                                                                                         	| 2.3.12  	| 91e8e890e3154169b7bb078e80efe979c006667b 	|
 | 28/07/22 	| *Minor bugfix*.                                                                                                                                                                                                                                                                                                                                                                                                      	| 2.3.11  	| c7114e4727e7eb2396d9af075c85df17b6c950e2 	|
 |          | (1) Update to `write_simspin_FITS`. The `observation` summary output by `build_datacube` was previously never saved to the FITS file output. However, this makes it difficult to reproduce if the only saved output is a FITS file. With this update, the list `observation` is now written to a table in EXTNUM = 3 for all FITS files produced.                                                                    |         |                                          |
 |          | (2) Update to `method = "gas"`. Particle images will now be output when method is `gas`, along with both the raw and observed mass, velocity and dispersion maps. This mode was not updated with the `spectral` and `velocity` modes in v2.3.8 upgrade. This has now been remedied.                                                                                                                                  |         |                                          |

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 <p>&nbsp;</p>
 
-v2.3.12 - A package for producing mock observations:
+v2.3.13 - A package for producing mock observations:
 
 SimSpin allows you to take a simulation of a galaxy and produce a data cube in the style of an Integral Field Spectroscopy (IFS) instrument. A mock observation is produced using three simple steps:
 

--- a/tests/testthat/test_build_datacube.R
+++ b/tests/testthat/test_build_datacube.R
@@ -516,8 +516,8 @@ test_that("Data cubes can be written to a single files", {
   expect_true(names(Rfits::Rfits_read(paste0(temp_loc, "/ss_gadget.FITS")))[ob_table_loc] == "OB_TABLE")
 
   expect_length(build_datacube(simspin_file = ss_eagle,
-                               telescope = telescope(type="IFU", lsf_fwhm = 3.6, signal_to_noise = 3),
-                               observing_strategy = observing_strategy(dist_z = 0.03, inc_deg = 45, blur = T),
+                               telescope = telescope(type="MUSE", fov = 10, signal_to_noise = NA),
+                               observing_strategy = observing_strategy(dist_z = 0.27, inc_deg = 60, blur = T, fwhm = 0.6),
                                method="gas",
                                write_fits = T, output_location = paste0(temp_loc, "/ss_eagle.FITS"),
                                split_save=F), built_cube_size)


### PR DESCRIPTION
*Minor bugfix*. Addressing Issue #59 (which was not actually fixed in previous attempt!). Making sure long entries (i.e. `wave_seq`, `vbin_seq` or `sbin_seq`) are never too long to be written to a FITS table. Change to range (i.e. min and max) to remove this as an issue. `pixel_region` and `psf_kernel` are also no longer written to the table (too long and rarely used). 