### PR TITLE
dev-align_fix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: SimSpin
 Type: Package
 Title: SimSpin - A package for the kinematic analysis of galaxy simulations
-Version: 2.3.14
+Version: 2.3.15
 Author: Katherine Harborne
 Maintainer: <katherine.harborne@icrar.org>
 Description: The purpose of this package is to provide a set of tools to "observe" simulations of galaxies as if you were an observer using an integral field unit (IFU). The galaxy model can be observed at a chosen inclination and an IFU observation can be produced in a selection of different spatial shapes (square, circular, and hexagonal) to account for the variety of CCD arrangements used by current telescopes. This data cube can be used to calculate the value an observer would measure for the spin parameter compared to the value that is measured directly from the simulation.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,8 @@
-# SimSpin v2.3.14 News
+# SimSpin v2.3.15 News
 
 ### Author: Kate Harborne
 
-### Last edit: 03/08/22
+### Last edit: 12/08/22
 
 Below is a table containing a summary of all changes made to SimSpin, since the date this file was created on 26/08/2021.
 
@@ -18,7 +18,8 @@ All changes are noted in the changelog table below.
 
 | Date     | Summary of change                                                                                                                                                                                                                                                                                                                                                                                                    | Version | Commit                                   |
 |----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|------------------------------------------|
-| 03/08/22 	| *Minor bugfix*. Addressing issue #62. Ensuring that raw images produced for any stellar mode observations (i.e. `method="spectral"` or `method="velocity"`) are consistent. New images added to spectral mode outputs (age and metallicity summaries) and all updated to mass weighted quantities.                                                                                                                   	| 2.3.14  	|                                          	|
+| 12/08/22 	| *Minor bugfix*. Addressing issue #64. Galaxy simulations will not be `align`ed if the input is from an 'nbody' simulation. This avoids the flip/flop effect in between snapshot time steps. Other changes include the default for `signal-to-noise` to be set to `NA` for ease in the SimSpin app. If no value is specified, no noise will be added to the observation. This is now updated also in the documentation.   	| 2.3.15  	|                                          	|
+| 03/08/22 	| *Minor bugfix*. Addressing issue #60. Ensuring that raw images produced for any stellar mode observations (i.e. `method="spectral"` or `method="velocity"`) are consistent. New images added to spectral mode outputs (age and metallicity summaries) and all updated to mass weighted quantities.                                                                                                                       	| 2.3.14  	| 6ab467718664be1db0fa653b0fb219d073472d43 	|
 | 01/08/22 	| *Minor bugfix*. Addressing Issue #59 (which was not actually fixed in previous attempt!). Making sure long entries (i.e. wave_seq, vbin_seq or sbin_seq) are never too long to be written to a FITS table. Change to range (i.e. min and max) to remove this as an issue.                                                                                                                                            	| 2.3.13  	| eee7c31c8686a5056ff3419136cb384d40693e50 	|
 | 29/07/22 	| *Minor bugfix*. Addressing Issue #59. Making sure any NA values within the `observation` list are re-written as "None" in characters before writing to FITS.                                                                                                                                                                                                                                                         	| 2.3.12  	| 91e8e890e3154169b7bb078e80efe979c006667b 	|
 | 28/07/22 	| *Minor bugfix*.                                                                                                                                                                                                                                                                                                                                                                                                      	| 2.3.11  	| c7114e4727e7eb2396d9af075c85df17b6c950e2 	|

--- a/R/telescope.R
+++ b/R/telescope.R
@@ -30,7 +30,8 @@
 #'@param lsf_fwhm Numeric describing the full-width half-maximum of the Gaussian
 #' line spread function.
 #'@param signal_to_noise Numeric describing the minimum signal-to-noise ratio per
-#' angstrom.
+#' angstrom. Default is NA, meaning that no noise will be added to the
+#' observation.
 #'@param method Providing backward compatibility for \code{method}
 #' specification. String to describe whether cubes output are "spectral", "gas",
 #' "sf gas" or "velocity" (as in SimSpin v1) along the z-axis. Default is
@@ -46,7 +47,7 @@
 
 telescope = function(type="IFU", fov, aperture_shape="circular", wave_range=c(3700,5700),
                      wave_centre, wave_res=1.04, spatial_res, filter="g", lsf_fwhm=2.65,
-                     signal_to_noise = 10, method){
+                     signal_to_noise = NA, method){
 
   if (!missing(method)){
 

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -722,15 +722,15 @@ globalVariables(c(".N", ":=", "Age", "Carbon", "CellSize", "Density", "Hydrogen"
 
   M = array(data = 0.0, dim = c(3,3))
 
-  M[1,1] = sum((galaxy_data$Mass * x * x) / ellip_radius)
-  M[1,2] = sum((galaxy_data$Mass * x * y) / ellip_radius)
-  M[1,3] = sum((galaxy_data$Mass * x * z) / ellip_radius)
+  M[1,1] = sum((galaxy_data$Mass * x * x) / ellip_radius, na.rm = T)
+  M[1,2] = sum((galaxy_data$Mass * x * y) / ellip_radius, na.rm = T)
+  M[1,3] = sum((galaxy_data$Mass * x * z) / ellip_radius, na.rm = T)
   M[2,1] = M[1,2]
-  M[2,2] = sum((galaxy_data$Mass * y * y) / ellip_radius)
-  M[2,3] = sum((galaxy_data$Mass * y * z) / ellip_radius)
+  M[2,2] = sum((galaxy_data$Mass * y * y) / ellip_radius, na.rm = T)
+  M[2,3] = sum((galaxy_data$Mass * y * z) / ellip_radius, na.rm = T)
   M[3,1] = M[1,3]
   M[3,2] = M[2,3]
-  M[3,3] = sum((galaxy_data$Mass * z * z) / ellip_radius)
+  M[3,3] = sum((galaxy_data$Mass * z * z) / ellip_radius, na.rm = T)
 
   return(M)
 }

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 <p>&nbsp;</p>
 
-v2.3.14 - A package for producing mock observations:
+v2.3.15 - A package for producing mock observations:
 
 SimSpin allows you to take a simulation of a galaxy and produce a data cube in the style of an Integral Field Spectroscopy (IFS) instrument. A mock observation is produced using three simple steps:
 

--- a/man/telescope.Rd
+++ b/man/telescope.Rd
@@ -14,7 +14,7 @@ telescope(
   spatial_res,
   filter = "g",
   lsf_fwhm = 2.65,
-  signal_to_noise = 10,
+  signal_to_noise = NA,
   method
 )
 }
@@ -47,7 +47,8 @@ of individual particles are calculated.}
 line spread function.}
 
 \item{signal_to_noise}{Numeric describing the minimum signal-to-noise ratio per
-angstrom.}
+angstrom. Default is NA, meaning that no noise will be added to the
+observation.}
 
 \item{method}{Providing backward compatibility for \code{method}
 specification. String to describe whether cubes output are "spectral", "gas",


### PR DESCRIPTION
Fix for Issue #64 and update that allows the new SimSpin app to work with the `signal_to_noise` parameter set to `NA` (i.e. not adding any noise to the images!). 

Changes include:

- Default for `signal_to_noise` in `telescope` is now NA.
- Behavior for observations of nbody simulations is that the code will not attempt to align the system so that timesteps can be analysed fairly.  