### PR TITLE
dev-voronoi_fix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: SimSpin
 Type: Package
 Title: SimSpin - A package for the kinematic analysis of galaxy simulations
-Version: 2.7.0
+Version: 2.7.1
 Author: Katherine Harborne
 Co-author: Alice Serene
 Maintainer: <katherine.harborne@icrar.org>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
-# SimSpin v2.7.0 News
+# SimSpin v2.7.1 News
 
-### Last edit: 25/10/23
+### Last edit: 17/11/23
 
 Below is a table containing a summary of all changes made to SimSpin, since the date this file was created on 26/08/2021.
 
@@ -16,6 +16,7 @@ All changes are noted in the changelog table below.
 
 | Date     	| Summary of change                                                                                                                                                                                                                                                                                                                                                                                                        	| Version 	| Commit                                   	| Author            |
 |----------	|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------	|---------	|------------------------------------------	| ----------------- |
+| 17/11/23 | Bug fix. The mass/flux in voronoi binned pixels were displayed as the sum of all the particles that fell within that bin. Now updated so that this value is averaged across the area of the bin (else outer larger bins appear brighter than inner ones...). Fixing issue #91. | 2.7.1 | e93c763c40ec670da58b37a353586887d0b34143 | Kate Harborne |
 | 25/10/23 | Adding functionality to voronoi bin individual pixels until the contain some minimum number of particles. This is important for reducing the effects of shot noise on the measured kinematics, especially in dispersion supported systems. We add a new function `voronoi`, which performs the tessellation algorithm as used in the [Vorbin python package](https://pypi.org/project/vorbin/) (Cappellari & Copin, 2003). When requested, this will add a new image to the `raw_images` output list called `voronoi_bins`, detailing the bin ids assigned to each pixel in the field-of-view of a given observation. | 2.7.0 | 2df3fc5e7f8aabd64c6aeb517c956ef30ffb50de | Kate Harborne |
 | 03/08/23 | Updating the information stored in the SimSpin files following a suggestion from SimSpin v2.5.0 paper review. Do not need to store the full spectrum for each particle. Just the weights and id's of the spectra within the template set. Reduces the simspin file sizes by factor of 100. Old SimSpin files will still work with the code, but will now issue a warning when using a file older than v2.6.0. Tagging for release. Thank you anonymous reviewer!!! | 2.6.0 | ecb9d38031b40e63216d6200409b24ece8fadb69 | Kate Harborne |
 | 19/07/23 | Tagging a stable release of the code to align with the submission of the SimSpin v2.5.0 paper to PASA on the 28th June 2023. | 2.5.0 | cc3b2018527995dfaf09130b1afbe4341566e4f7 | Kate Harborne |

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -1484,6 +1484,8 @@ globalVariables(c(".N", ":=", "Age", "Carbon", "CellSize", "Density", "Hydrogen"
     vorbin_map[part_in_spaxel$pixel_pos[[i]]] = i
 
     galaxy_sample = galaxy_data[ID %in% part_in_spaxel$val[[i]]]
+    pixel_size = length(unique(galaxy_sample$pixel_pos))
+    galaxy_sample$Mass = galaxy_sample$Mass / pixel_size
 
     luminosity = numeric(length(observation$wave_seq)) # initiallise a spectrum array for this pixel
 
@@ -1528,7 +1530,7 @@ globalVariables(c(".N", ":=", "Age", "Carbon", "CellSize", "Density", "Hydrogen"
     # transform luminosity into flux detected at telescope
     #    flux in units erg/s/cm^2/Ang
     spectral_dist = (luminosity*.lsol_to_erg) / (4 * pi * (observation$lum_dist*.mpc_to_cm)^2) /
-                    (1 + observation$z)
+                    (1 + observation$z) / pixel_size
 
     for (bin in 1:length(part_in_spaxel$pixel_pos[[i]])){
       spectra[part_in_spaxel$pixel_pos[[i]][bin], ] = spectral_dist
@@ -1571,6 +1573,8 @@ globalVariables(c(".N", ":=", "Age", "Carbon", "CellSize", "Density", "Hydrogen"
                      vorbin_map = i
 
                      galaxy_sample = galaxy_data[ID %in% part_in_spaxel$val[[i]]]
+                     pixel_size = length(unique(galaxy_sample$pixel_pos))
+                     galaxy_sample$Mass = galaxy_sample$Mass / pixel_size
 
                      luminosity = numeric(length(observation$wave_seq)) # initialize a spectrum array for this pixel
 
@@ -1616,7 +1620,7 @@ globalVariables(c(".N", ":=", "Age", "Carbon", "CellSize", "Density", "Hydrogen"
                      # transform luminosity into flux detected at telescope
                      #    flux in units erg/s/cm^2/Ang
                      spectra = (luminosity*.lsol_to_erg) / (4 * pi * (observation$lum_dist*.mpc_to_cm)^2) /
-                               (1 + observation$z)
+                               (1 + observation$z) / pixel_size
                      lum_map = sum(spectra, na.rm = T)
                                #.bandpass(wave = observation$wave_seq,
                                #          flux = spectra,
@@ -1681,6 +1685,8 @@ globalVariables(c(".N", ":=", "Age", "Carbon", "CellSize", "Density", "Hydrogen"
     vorbin_map[part_in_spaxel$pixel_pos[[i]]] = i
 
     galaxy_sample = galaxy_data[ID %in% part_in_spaxel$val[[i]]]
+    pixel_size = length(unique(galaxy_sample$pixel_pos))
+    galaxy_sample$Mass = galaxy_sample$Mass / pixel_size
 
     if (mass_flag){
 
@@ -1721,7 +1727,7 @@ globalVariables(c(".N", ":=", "Age", "Carbon", "CellSize", "Density", "Hydrogen"
         #    flux in units erg/s/cm^2/Ang
         flux_spectra =
         (lum*.lsol_to_erg*scale_frac) / (4 * pi * (observation$lum_dist*.mpc_to_cm)^2) /
-          (1 + observation$z)
+          (1 + observation$z) / pixel_size
 
         # computing the r-band luminosity per particle from spectra
         band_lum[p] = .bandpass(wave = observation$wave_seq,
@@ -1786,6 +1792,8 @@ globalVariables(c(".N", ":=", "Age", "Carbon", "CellSize", "Density", "Hydrogen"
                      vorbin_map = i
 
                      galaxy_sample = galaxy_data[ID %in% part_in_spaxel$val[[i]]]
+                     pixel_size = length(unique(galaxy_sample$pixel_pos))
+                     galaxy_sample$Mass = galaxy_sample$Mass / pixel_size
 
                      if (mass_flag){
 
@@ -1827,7 +1835,7 @@ globalVariables(c(".N", ":=", "Age", "Carbon", "CellSize", "Density", "Hydrogen"
 
                          flux_spectra =
                            (lum*.lsol_to_erg*scale_frac) / (4 * pi * (observation$lum_dist*.mpc_to_cm)^2) /
-                           (1 + observation$z)
+                           (1 + observation$z) / pixel_size
 
 
                          # computing the r-band luminosity per particle from spectra
@@ -1910,9 +1918,10 @@ globalVariables(c(".N", ":=", "Age", "Carbon", "CellSize", "Density", "Hydrogen"
     vorbin_map[part_in_spaxel$pixel_pos[[i]]] = i
 
     galaxy_sample = galaxy_data[ID %in% part_in_spaxel$val[[i]]]
+    pixel_size = length(unique(galaxy_sample$pixel_pos))
+    galaxy_sample$Mass = galaxy_sample$Mass / pixel_size
 
     # adding the "gaussians" of each particle to the velocity bins
-
     v_dist = .sum_gas_velocities(galaxy_sample = galaxy_sample, observation = observation)
 
     for (bin in 1:length(part_in_spaxel$pixel_pos[[i]])){
@@ -1956,6 +1965,8 @@ globalVariables(c(".N", ":=", "Age", "Carbon", "CellSize", "Density", "Hydrogen"
                      vorbin_map = i
 
                      galaxy_sample = galaxy_data[ID %in% part_in_spaxel$val[[i]]]
+                     pixel_size = length(unique(galaxy_sample$pixel_pos))
+                     galaxy_sample$Mass = galaxy_sample$Mass / pixel_size
 
                      # adding the "gaussians" of each particle to the velocity bins
                      vel_spec = .sum_gas_velocities(galaxy_sample = galaxy_sample, observation = observation)

--- a/man/Distance-class.Rd
+++ b/man/Distance-class.Rd
@@ -22,13 +22,13 @@ An S4 class to represent projected distance to a galaxy
 }
 \section{Functions}{
 \itemize{
-\item \code{kpc_per_arcsec}: Query the kpc_per_arcsec of a Distance object
+\item \code{kpc_per_arcsec()}: Query the kpc_per_arcsec of a Distance object
 
-\item \code{Mpc}: Query the Mpc of a Distance object
+\item \code{Mpc()}: Query the Mpc of a Distance object
 
-\item \code{z}: Query the z of a Distance object
+\item \code{z()}: Query the z of a Distance object
+
 }}
-
 \section{Slots}{
 
 \describe{

--- a/man/Pointing-class.Rd
+++ b/man/Pointing-class.Rd
@@ -19,11 +19,11 @@ An S4 class to represent the telescope pointing relative to the galaxy centre
 }
 \section{Functions}{
 \itemize{
-\item \code{xy_deg}: Query the xy_deg of a Pointing object
+\item \code{xy_deg()}: Query the xy_deg of a Pointing object
 
-\item \code{xy_kpc}: Query the xy_kpc of a Pointing object
+\item \code{xy_kpc()}: Query the xy_kpc of a Pointing object
+
 }}
-
 \section{Slots}{
 
 \describe{


### PR DESCRIPTION
Fixing issue #91 - Modifying the flux/mass in Voronoi binned pixels. Previously, taking the sum of flux in all pixels to represent the flux at that bin. Now performing the average such that mass and flux maps of Voronoi binned galaxies do not appear brighter in outer bins which are larger. 