### PR TITLE
dev_TNG-fix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: SimSpin
 Type: Package
 Title: SimSpin - A package for the kinematic analysis of galaxy simulations
-Version: 2.8.7
+Version: 2.8.8
 Author: Katherine Harborne
 Co-author: Alice Serene
 Maintainer: <katherine.harborne@icrar.org>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
-# SimSpin v2.8.7 News
+# SimSpin v2.8.8 News
 
-### Last edit: 25/04/2024
+### Last edit: 19/07/2024
 
 
 Below is a table containing a summary of all changes made to SimSpin, since the date this file was created on 26/08/2021.
@@ -17,7 +17,8 @@ All changes are noted in the changelog table below.
 
 | Date     	| Summary of change                                                                                                                                                                                                                                                                                                                                                                                                        	| Version 	| Commit                                   	| Author            |
 |----------	|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------	|---------	|------------------------------------------	| ----------------- |
-| 17/06/24 | Adding measurement of radial gas temperature to the output of the `sim_analysis` function | 2.8.7 |  | Kate Harborne |
+| 19/07/24 | *Bug fix.* `.check_names()` function fails for TNG outputs if one 1 gas particle is contained in the snapshot due to indexing errors. Added in a catch for this error to prevent unnecessary code failure. | 2.8.8 |  | Kate Harborne |
+| 17/06/24 | Adding measurement of radial gas temperature to the output of the `sim_analysis` function | 2.8.7 | ad32eb746479240c4106296999957d6ff74aecdd | Kate Harborne |
 | 25/04/24 | *Bug fix.* Providing a meaningful error message from the `voronoi.R` function when you cannot bin enough particles to reach the requested voronoi bin N limit. Resolves issue #105. | 2.8.6 | 4e8f0af0ebc0e43cc31729978deb3a554e039f6b | Kate Harborne |
 | 23/04/24 | *Bug fix.* Fixing a bug in `write_simspin_FITS.R` where the observed SFR maps were not being written to the FITS file as an index was incorrect - now fixed and checks written to ensure that the `OBS_SFR` and `RAW_SFR` map extensions are not identical. | 2.8.5 | 21b5d219de05927918c5569c11e79709cea250df | Kate Harborne |
 | 26/03/24 | *Bug fix.* Updating the read in functions for cosmological models input to prevent the code falling over when attributes are not provided for Datasets that are unnecesary for SimSpin to function. This means HDF5 files extracted directly from the TNG database for galaxy cutouts will now produce outputs successfully, fixing Issue #95. | 2.8.4 | cdb17c1a2aaa1f2b8ea973eaad44fb22a625663b | Kate Harborne |

--- a/R/read_files.R
+++ b/R/read_files.R
@@ -867,8 +867,11 @@
   if ("GFM_Metals" %in% current_names){
     id_to_remove = which(current_names == "GFM_Metals")
 
-    particle_list$`ElementAbundance/Oxygen` = particle_list$GFM_Metals[5,]
-    particle_list$`ElementAbundance/Hydrogen` = particle_list$GFM_Metals[1,]
+    one_p_flag = FALSE
+    if (is.null(dim(particle_list$Coordinates))){one_p_flag = TRUE}
+
+    particle_list$`ElementAbundance/Oxygen` = if(one_p_flag){particle_list$GFM_Metals[5]}else{particle_list$GFM_Metals[5,]}
+    particle_list$`ElementAbundance/Hydrogen` = if(one_p_flag){particle_list$GFM_Metals[1]}else{particle_list$GFM_Metals[1,]}
 
     particle_list = particle_list[-id_to_remove]
   }

--- a/tests/testthat/test_make_simspin_file.R
+++ b/tests/testthat/test_make_simspin_file.R
@@ -773,9 +773,9 @@ test_that("No errors when HDF5 files input only have a single gas particle - Mag
     data[["PartType0/"]]$link_delete(paste0(PT0_attr[i]))
 
     data[[paste0("PartType0/",PT0_attr[i])]] = gas[[i]]
-    hdf5r::h5attr(data[[paste0("PartType0/",PT0_attr[i])]], "a_scaling") = aexp
-    hdf5r::h5attr(data[[paste0("PartType0/",PT0_attr[i])]], "h_scaling") = hexp
-    hdf5r::h5attr(data[[paste0("PartType0/",PT0_attr[i])]], "to_cgs") = cgs
+    hdf5r::h5attr(data[[paste0("PartType0/",PT0_attr[i])]], "aexp-scale-exponent") = aexp
+    hdf5r::h5attr(data[[paste0("PartType0/",PT0_attr[i])]], "h-scale-exponent") = hexp
+    hdf5r::h5attr(data[[paste0("PartType0/",PT0_attr[i])]], "CGSConversionFactor") = cgs
   }
 
   hdf5r::h5close(data)

--- a/tests/testthat/test_make_simspin_file.R
+++ b/tests/testthat/test_make_simspin_file.R
@@ -724,7 +724,7 @@ test_that("No errors when HDF5 files input only have a single gas particle - TNG
 
     data[[paste0("PartType0/",PT0_attr[i])]] = gas[[i]]
     hdf5r::h5attr(data[[paste0("PartType0/",PT0_attr[i])]], "a_scaling") = aexp
-    hdf5r::h5attr(data[[paste0("PartType0/",PT0_attr[i])]], "h_scaling") = h
+    hdf5r::h5attr(data[[paste0("PartType0/",PT0_attr[i])]], "h_scaling") = hexp
     hdf5r::h5attr(data[[paste0("PartType0/",PT0_attr[i])]], "to_cgs") = cgs
   }
 
@@ -774,7 +774,7 @@ test_that("No errors when HDF5 files input only have a single gas particle - Mag
 
     data[[paste0("PartType0/",PT0_attr[i])]] = gas[[i]]
     hdf5r::h5attr(data[[paste0("PartType0/",PT0_attr[i])]], "a_scaling") = aexp
-    hdf5r::h5attr(data[[paste0("PartType0/",PT0_attr[i])]], "h_scaling") = h
+    hdf5r::h5attr(data[[paste0("PartType0/",PT0_attr[i])]], "h_scaling") = hexp
     hdf5r::h5attr(data[[paste0("PartType0/",PT0_attr[i])]], "to_cgs") = cgs
   }
 

--- a/tests/testthat/test_make_simspin_file.R
+++ b/tests/testthat/test_make_simspin_file.R
@@ -668,4 +668,122 @@ test_that("Expect header information in each of the built simspin files.", {
 
 })
 
+# Testing that a single gas particle doesn't cause errors in simspin file creation
+test_that("No errors when HDF5 files input only have a single gas particle - TNG", {
 
+  file.copy(from = ss_illustris, to = paste0(temp_loc, "/SimSpin_example_illustris_copy.hdf5"), overwrite = T)
+  data = hdf5r::h5file(paste0(temp_loc, "/SimSpin_example_illustris_copy.hdf5"), mode = "r+") # read in the eagle file and rename the RubLabel
+
+  # read_files lines 676-713
+  PT0_attr = hdf5r::list.datasets(data[["PartType0"]])    # get list of fields
+
+  expected_names_gas = c("Coordinates", "Density", "Masses", "ParticleIDs",
+                         "GFM_Metals", "GFM_Metallicity",
+                         "StarFormationRate", "Velocities",
+                         "ElectronAbundance", "InternalEnergy")
+  PT0_attr = PT0_attr[which(PT0_attr %in% expected_names_gas)] # trim list to only read in necessary data sets
+
+  n_gas_prop = length(PT0_attr)                           # how many fields?
+  gas = vector("list", n_gas_prop)                        # make a vector
+  names(gas) = PT0_attr                                   # assign field names to elements
+
+  # loop through the fields,
+  # assign them their conversion factor attributes,
+  # and then convert their data
+  for (i in 1:n_gas_prop){
+    aexp = tryCatch(expr = {hdf5r::h5attr(data[[paste0("PartType0/",PT0_attr[i])]], "a_scaling")},
+                    error = function(e){NULL})
+    hexp = tryCatch(expr = {hdf5r::h5attr(data[[paste0("PartType0/",PT0_attr[i])]], "h_scaling")},
+                    error = function(e){NULL})
+    cgs  = tryCatch(expr = {hdf5r::h5attr(data[[paste0("PartType0/",PT0_attr[i])]], "to_cgs")},
+                    error = function(e){NULL})
+    if (any(is.null(aexp), is.null(hexp), is.null(cgs))){
+      aexp = tryCatch(expr = {hdf5r::h5attr(data[[paste0("PartType0/",PT0_attr[i])]], "aexp-scale-exponent")},
+                      error = function(e){NULL})
+      hexp = tryCatch(expr = {hdf5r::h5attr(data[[paste0("PartType0/",PT0_attr[i])]], "h-scale-exponent")},
+                      error = function(e){NULL})
+      cgs  = tryCatch(expr = {hdf5r::h5attr(data[[paste0("PartType0/",PT0_attr[i])]], "CGSConversionFactor")},
+                      error = function(e){NULL})
+      if (any(is.null(aexp), is.null(hexp), is.null(cgs))){
+        stop("Error: Attributes listed incorrectly. \n
+               Please check that the scaling factors for conversion between comoving and physical coordinates are included in the input file as attributes for each dataset. \n
+               See https://kateharborne.github.io/SimSpin/examples/generating_hdf5.html#hydrodynamical-simulations for more details.")}
+    }
+    if (cgs == 0) {cgs = 1}                                                   # converting 0 values to 1
+
+    gas[[i]] =
+      hdf5r::readDataSet(data[[paste0("PartType0/",PT0_attr[i])]])
+
+    if (length(dim(gas[[i]]))==2){
+      gas[[i]] = gas[[i]][,1]
+    } else {
+      gas[[i]] = gas[[i]][1]
+    }
+
+    data[["PartType0/"]]$link_delete(paste0(PT0_attr[i]))
+
+    data[[paste0("PartType0/",PT0_attr[i])]] = gas[[i]]
+    hdf5r::h5attr(data[[paste0("PartType0/",PT0_attr[i])]], "a_scaling") = aexp
+    hdf5r::h5attr(data[[paste0("PartType0/",PT0_attr[i])]], "h_scaling") = h
+    hdf5r::h5attr(data[[paste0("PartType0/",PT0_attr[i])]], "to_cgs") = cgs
+  }
+
+  hdf5r::h5close(data)
+
+  ss_file = make_simspin_file(filename = paste0(temp_loc, "/SimSpin_example_illustris_copy.hdf5"), write_to_file = F)
+
+  expect_length(ss_file, ss_file_length)
+
+  unlink(paste0(temp_loc, "/SimSpin_example_illustris_copy.hdf5"))
+
+})
+
+test_that("No errors when HDF5 files input only have a single gas particle - Magneticum", {
+
+  file.copy(from = ss_magneticum, to = paste0(temp_loc, "/SimSpin_example_magneticum_copy.hdf5"), overwrite = T)
+  data = hdf5r::h5file(paste0(temp_loc, "/SimSpin_example_magneticum_copy.hdf5"), mode = "r+") # read in the eagle file and rename the RubLabel
+
+  PT0_attr = hdf5r::list.datasets(data[["PartType0"]])
+
+  expected_names_gas = c("Coordinates", "Density", "Mass", "ParticleIDs",
+                         "Metallicity",  "StarFormationRate", "Velocity",
+                         "SmoothingLength", "Temperature", "InternalEnergy")
+  PT0_attr = PT0_attr[which(PT0_attr %in% expected_names_gas)] # trim list to only read in necessary data sets
+
+  n_gas_prop = length(PT0_attr)
+  gas = vector("list", n_gas_prop)
+  names(gas) = PT0_attr
+
+  for (i in 1:n_gas_prop){
+    aexp = hdf5r::h5attr(data[[paste0("PartType0/",PT0_attr[i])]], "aexp-scale-exponent")
+    hexp = hdf5r::h5attr(data[[paste0("PartType0/",PT0_attr[i])]], "h-scale-exponent")
+    cgs  = hdf5r::h5attr(data[[paste0("PartType0/",PT0_attr[i])]], "CGSConversionFactor")
+    gas[[i]] =
+      hdf5r::readDataSet(data[[paste0("PartType0/",PT0_attr[i])]])
+
+    gas[[i]] =
+      hdf5r::readDataSet(data[[paste0("PartType0/",PT0_attr[i])]])
+
+    if (length(dim(gas[[i]]))==2){
+      gas[[i]] = gas[[i]][,1]
+    } else {
+      gas[[i]] = gas[[i]][1]
+    }
+
+    data[["PartType0/"]]$link_delete(paste0(PT0_attr[i]))
+
+    data[[paste0("PartType0/",PT0_attr[i])]] = gas[[i]]
+    hdf5r::h5attr(data[[paste0("PartType0/",PT0_attr[i])]], "a_scaling") = aexp
+    hdf5r::h5attr(data[[paste0("PartType0/",PT0_attr[i])]], "h_scaling") = h
+    hdf5r::h5attr(data[[paste0("PartType0/",PT0_attr[i])]], "to_cgs") = cgs
+  }
+
+  hdf5r::h5close(data)
+
+  ss_file = make_simspin_file(filename = paste0(temp_loc, "/SimSpin_example_magneticum_copy.hdf5"), write_to_file = F)
+
+  expect_length(ss_file, ss_file_length)
+
+  unlink(paste0(temp_loc, "/SimSpin_example_magneticum_copy.hdf5"))
+
+})


### PR DESCRIPTION
*Bug fix.* `.check_names()` function fails for TNG outputs if one 1 gas particle is contained in the snapshot due to indexing errors. Added in a catch for this error to prevent unnecessary code failure.

Minor version bump to v2.8.8.