### PR TITLE
dev-spectral_weights

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: SimSpin
 Type: Package
 Title: SimSpin - A package for the kinematic analysis of galaxy simulations
-Version: 2.10.4
+Version: 2.10.5
 Author: Katherine Harborne
 Co-author: Alice Serene
 Maintainer: <katherine.harborne@icrar.org>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
-# SimSpin v2.10.4 News
+# SimSpin v2.10.5 News
 
-### Last edit: 24/03/2025
+### Last edit: 22/08/2025
 
 Below is a table containing a summary of all changes made to SimSpin, since the date this file was created on 26/08/2021.
 
@@ -16,7 +16,8 @@ All changes are noted in the changelog table below.
 
 | Date     	| Summary of change                                                                                                                                                                                                                                                                                                                                                                                                        	| Version 	| Commit                                   	| Author            |
 |----------	|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------	|---------	|------------------------------------------	| ----------------- |
-| 24/04/25 | *Bug fix* Variance cube should not be just the inverse of the added noise, updated to reflect the inverse variance in the full velocity/spectral cube. | 2.10.4 |  | Kate Harborne |
+| 22/08/25 | *Bug fix* NaN's triggered in spectral weights when using BC03 templates and stars have ages closest to the lowest bin (age = 0). Interpolation done in log space causing -Inf values that cannot be interpolated. Added fix and tests to check this in future. | 2.10.5 |  | Kate Harborne |
+| 24/04/25 | *Bug fix* Variance cube should not be just the inverse of the added noise, updated to reflect the inverse variance in the full velocity/spectral cube. | 2.10.4 | 968252ffdc131f85c592f5771162ad54c4242dc5 | Kate Harborne |
 | 24/04/25 | *New feature!* Adding support for reading and processing COLIBRE files as cut out using SWIFTsimio. | 2.10.3 | 476135d54d8133eaafee981a9ebffcd636d01d7b | Kate Harborne |
 | 16/04/25 | *Bug fix* `optim` returning the lower bound for dispersion (i.e. sigma = 1e10) frequently. Changing the lower bound value to a physically meaningful lower limit (i.e. FWHM_inst/2) and setting any fit values below this to 0. | 2.10.2 | e088ae99e1079f69616f767357475f70c9604394 | Kate Harborne |
 | 07/03/25 | *Bug fix* `tryCatch` in `build_datacube` meant we were missing the errors from LOSVD fit due to `optim` returning non-finite values when approaching the lower bound for dispersion (i.e. sigma = 0). Fixed Issue #121 by adjusting this lower bound to be small but non-zero. Further adjusted the naming convention in `write_simspin_file` for the `input_simspin_file` > `input_simspin_file_path` for clarity. Old code will not fail, but will issue a warning. Closing Issue #109. | 2.10.1 | 35c647470566faf8f831382863506883af57aa47 | Kate Harborne |

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -462,6 +462,12 @@ globalVariables(c(".N", ":=", "Age", "Carbon", "CellSize", "Density", "filter_lu
   if(log){
     params = log(params)
     x = log(x)
+    if(any(is.infinite(params))){
+      params[is.infinite(params)] = 0
+    }
+    if(any(is.infinite(x))){
+      x[is.infinite(x)] = 0
+    }
   }
   interp = approx(params, 1:length(params), xout=x)$y
   IDlo = floor(interp)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 <p>&nbsp;</p>
 
-v2.10.4 - A package for producing mock observations:
+v2.10.5 - A package for producing mock observations:
 
 
 SimSpin allows you to take a simulation of a galaxy and produce a data cube in the style of an Integral Field Spectroscopy (IFS) instrument. You can find the live documentation for this code at the following [website](https://kateharborne.github.io/SimSpin/). 

--- a/tests/testthat/test_utilities.R
+++ b/tests/testthat/test_utilities.R
@@ -96,6 +96,13 @@ test_that("SED is returned as a list when only one age and metallicity are given
   expect_true(data.table::is.data.table(.spectral_weights(Metallicity = 1e-4, Age = 5, Template = temp, cores = 1)))
 })
 
+test_that("spectral weights are returned as a list when only in minimum BC03 age bin", {
+  temp = SimSpin::BC03lr
+  expect_type(.spectral_weights(Metallicity = 1e-4, Age = 6e-5, Template = temp, cores = 1), "list")
+  expect_true(data.table::is.data.table(.spectral_weights(Metallicity = 1e-4, Age = 6e-5, Template = temp, cores = 1)))
+  expect_false(any(is.na(.spectral_weights(Metallicity = 1e-4, Age = 6e-5, Template = temp, cores = 1))))
+})
+
 test_that("Filters and templates can be loaded successfully", {
   BC03lr = SimSpin::BC03lr
   BC03hr = SimSpin::BC03hr


### PR DESCRIPTION
Fix for bug #130 - When using the BC03 templates, the lowest age bin is associated with 0. When interpolating the spectral weights, we log the age bins (making the lowest age bin -Inf) which then causes error with the interpolation. 

We now check for infinite values, retuning them to 0 before interpolating in log space, such that NaN's are not returned. 

Added tests:

- Check that particles with the lowest ages do not produce a spectral weight with NaN in the list.