### PR TITLE
dev-generic

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: SimSpin
 Type: Package
 Title: SimSpin - A package for the kinematic analysis of galaxy simulations
-Version: 2.10.5
+Version: 2.10.6
 Author: Katherine Harborne
 Co-author: Alice Serene
 Maintainer: <katherine.harborne@icrar.org>

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,7 +32,7 @@ Imports:
     stringr,
     stats,
     utils
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.3
 Suggests: 
     testthat,
     knitr,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
-# SimSpin v2.10.5 News
+# SimSpin v2.10.6 News
 
-### Last edit: 22/08/2025
+### Last edit: 29/10/2025
 
 Below is a table containing a summary of all changes made to SimSpin, since the date this file was created on 26/08/2021.
 
@@ -16,7 +16,8 @@ All changes are noted in the changelog table below.
 
 | Date     	| Summary of change                                                                                                                                                                                                                                                                                                                                                                                                        	| Version 	| Commit                                   	| Author            |
 |----------	|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------	|---------	|------------------------------------------	| ----------------- |
-| 22/08/25 | *Bug fix* NaN's triggered in spectral weights when using BC03 templates and stars have ages closest to the lowest bin (age = 0). Interpolation done in log space causing -Inf values that cannot be interpolated. Added fix and tests to check this in future. | 2.10.5 |  | Kate Harborne |
+| 29/10/25 | *New feature!* Addressing issue #133 - adding support for generic HDF5 simulation input files for `make_simspin_file` (written in line with the documentation given [here](https://kateharborne.github.io/SimSpin/examples/generating_hdf5.html).| 2.10.6 |  | Kate Harborne |
+| 22/08/25 | *Bug fix* NaN's triggered in spectral weights when using BC03 templates and stars have ages closest to the lowest bin (age = 0). Interpolation done in log space causing -Inf values that cannot be interpolated. Added fix and tests to check this in future. | 2.10.5 | 68f26faff6799dbbf5c934aa702316a223786743 | Kate Harborne |
 | 24/04/25 | *Bug fix* Variance cube should not be just the inverse of the added noise, updated to reflect the inverse variance in the full velocity/spectral cube. | 2.10.4 | 968252ffdc131f85c592f5771162ad54c4242dc5 | Kate Harborne |
 | 24/04/25 | *New feature!* Adding support for reading and processing COLIBRE files as cut out using SWIFTsimio. | 2.10.3 | 476135d54d8133eaafee981a9ebffcd636d01d7b | Kate Harborne |
 | 16/04/25 | *Bug fix* `optim` returning the lower bound for dispersion (i.e. sigma = 1e10) frequently. Changing the lower bound value to a physically meaningful lower limit (i.e. FWHM_inst/2) and setting any fit values below this to 0. | 2.10.2 | e088ae99e1079f69616f767357475f70c9604394 | Kate Harborne |

--- a/R/read_files.R
+++ b/R/read_files.R
@@ -163,6 +163,7 @@
     horizonagn = F
     illustristng = F
     colibre = F
+    generic = F
   } else {
 
     if ("SimulationName" %in% names(head)){

--- a/R/read_files.R
+++ b/R/read_files.R
@@ -181,7 +181,7 @@
       if(stringr::str_detect(stringr::str_to_lower(head$RunLabel), "magneticum")){magneticum = T}else{magneticum=F}
       if(stringr::str_detect(stringr::str_to_lower(head$RunLabel), "horizon")){horizonagn = T}else{horizonagn = F}
       if(stringr::str_detect(stringr::str_to_lower(head$RunLabel), "colibre")){colibre = T}else{colibre = F}
-      if(!all(eagle, illustristng, magneticum, horizonagn, colibre, gadget2)){generic=T}else{generic = F}
+      if(!any(eagle, illustristng, magneticum, horizonagn, colibre, gadget2)){generic=T}else{generic = F}
     }
   }
 

--- a/R/read_files.R
+++ b/R/read_files.R
@@ -138,13 +138,22 @@
          See https://kateharborne.github.io/SimSpin/examples/generating_hdf5.html#header for more details.")
   }
 
-  other_headers = c("NumPart_ThisFile", "NumPart_Total", "Omega0", "OmegaLambda", "Omega_m", "Omega_lambda", "Omega_r")
+  other_headers = c("NumPart_ThisFile", "NumPart_Total")
   if (!any(other_headers %in% names(head))){
     stop("Error. Missing a required header field. \n
          One of `NumPart_ThisFile`, `NumPart_Total` or Omega parameters are missing. \n
          See https://kateharborne.github.io/SimSpin/examples/generating_hdf5.html#header for more details.")
   }
 
+  cosmo_headers = c("Omega0", "OmegaLambda", "Omega_m", "Omega_lambda", "Omega_r", "OmegaM", "OmegaL", "OmegaR")
+  if (!any(cosmo_headers %in% names(head))){
+    warning("Warning! Missing Omega parameters from header.\n
+    Using default Planck 2018 values OmegaM = 0.301, OmegaL = 0.699, OmegaR = 8.985075e-05.\n
+            See https://kateharborne.github.io/SimSpin/examples/generating_hdf5.html#header for more details.")
+    head$OmegaM = 0.301
+    head$OmegaL = 0.699
+    head$OmegaR = 8.985075e-05
+  }
 
   # default (if header if blank) is a gadget file.
   if(is.null(head$RunLabel) && is.null(head$SimulationName)){
@@ -1003,7 +1012,17 @@
                            "Metallicity",
                            "StarFormationRate", "Velocity", "SmoothingLength",
                            "Temperature", "InternalEnergy")
+
+    if (!"ElementAbundance/Oxygen" %in% PT0_attr & "Oxygen" %in% PT0_attr){
+      expected_names_gas[which(expected_names_gas == "ElementAbundance/Oxygen")] = "Oxygen"
+    }
+    if (!"ElementAbundance/Hydrogen" %in% PT0_attr & "Hydrogen" %in% PT0_attr){
+      expected_names_gas[which(expected_names_gas == "ElementAbundance/Hydrogen")] = "Hydrogen"
+    }
+
     PT0_attr = PT0_attr[which(PT0_attr %in% expected_names_gas)] # trim list to only read in necessary data sets
+
+
 
     n_gas_prop = length(PT0_attr)
     gas = vector("list", n_gas_prop)
@@ -1123,6 +1142,11 @@
     names(particle_list) <- current_names
   }
 
+  if ("Hydrogen" %in% current_names & stringr::str_detect(type, "Generic")){
+    current_names[which(current_names == "Hydrogen")] <- "ElementAbundance/Hydrogen"
+    names(particle_list) <- current_names
+  }
+
   if ("SmoothedElementAbundance/Hydrogen" %in% current_names & type == "EAGLE" |
       "SmoothedElementAbundance/Hydrogen" %in% current_names & type == "HAGN" ){
     current_names[which(current_names == "SmoothedElementAbundance/Hydrogen")] <- "ElementAbundance/Hydrogen"
@@ -1131,6 +1155,11 @@
 
   if ("ElementMassFractions/Hydrogen" %in% current_names & type == "Colibre"){
     current_names[which(current_names == "ElementMassFractions/Hydrogen")] <- "ElementAbundance/Hydrogen"
+    names(particle_list) <- current_names
+  }
+
+  if ("Oxygen" %in% current_names & stringr::str_detect(type, "Generic")){
+    current_names[which(current_names == "Oxygen")] <- "ElementAbundance/Oxygen"
     names(particle_list) <- current_names
   }
 

--- a/R/read_files.R
+++ b/R/read_files.R
@@ -5,7 +5,6 @@
 # Description: Hidden from user functions for reading various input simulation
 #              files, including
 #                 - Gadget binaries
-#                 - Tipsy binaries
 #                 - Gadget HDF5
 #                 - EAGLE
 #                 - IllustrisTNG

--- a/R/read_files.R
+++ b/R/read_files.R
@@ -977,10 +977,131 @@
 
   } else {star_part=NULL; ssp=NULL}
 
-  head$Type = "Colibre"
   return(list(star_part=star_part, gas_part=gas_part, head=head, ssp=ssp))
 
 }
+
+# Function to read in data for a generic file formatted as described in the documentation (i.e. possibly for a format not yet supported)
+.generic_read_hdf5 = function(data, head, cores){
+
+  head$Type = paste0("Generic read - ", head$RunLabel)
+  head$H0 = head$HubbleParam * 100
+  names(head)[names(head) == "Omega_m"] = "OmegaM"
+  names(head)[names(head) == "Omega_lambda"] = "OmegaL"
+  names(head)[names(head) == "Omega_r"] = "OmegaR"
+
+  groups = hdf5r::list.groups(data) # What particle data is present?
+  groups = groups[stringr::str_detect(groups, "PartType")] # Pick out PartTypeX groups
+
+  if ("PartType0" %in% groups){ # If gas particles are present in the file
+
+    PT0_attr = hdf5r::list.datasets(data[["PartType0"]])
+
+    expected_names_gas = c("Coordinates", "Density", "Mass", "ParticleIDs",
+                           "ElementAbundance/Oxygen", "ElementAbundance/Hydrogen",
+                           "Metallicity",
+                           "StarFormationRate", "Velocity", "SmoothingLength",
+                           "Temperature", "InternalEnergy")
+    PT0_attr = PT0_attr[which(PT0_attr %in% expected_names_gas)] # trim list to only read in necessary data sets
+
+    n_gas_prop = length(PT0_attr)
+    gas = vector("list", n_gas_prop)
+    names(gas) = PT0_attr
+
+    for (i in 1:n_gas_prop){
+      aexp = hdf5r::h5attr(data[[paste0("PartType0/",PT0_attr[i])]], "aexp-scale-exponent")
+      hexp = hdf5r::h5attr(data[[paste0("PartType0/",PT0_attr[i])]], "h-scale-exponent")
+      cgs  = hdf5r::h5attr(data[[paste0("PartType0/",PT0_attr[i])]], "CGSConversionFactor")
+      gas[[i]] =
+        hdf5r::readDataSet(data[[paste0("PartType0/",PT0_attr[i])]]) * head$Time^(aexp) * head$HubbleParam^(hexp) * cgs
+    }
+
+    gas = .check_names(gas, type="Colibre")
+
+    colibre_gas_names = c("SmoothingLength", "Temperature", "InternalEnergy")
+    if (!all(colibre_gas_names %in% names(gas))){
+      stop("Error. Missing a necessary dataset for COLIBRE PartType0. \n
+           Either `SmoothingLength`, `Temperature`, or `InternalEnergy`. \n
+           See https://kateharborne.github.io/SimSpin/examples/generating_hdf5.html#parttype0 for more info.")
+    }
+
+    one_p_flag = FALSE
+    if (is.null(dim(gas$Coordinates))){one_p_flag = TRUE}
+
+    gas_part = data.table::data.table("ID" = gas$ParticleIDs,
+                                      "x"  = if(one_p_flag){gas$Coordinates[1]*.cm_to_kpc}else{gas$Coordinates[1,]*.cm_to_kpc}, # Coordinates in kpc
+                                      "y"  = if(one_p_flag){gas$Coordinates[2]*.cm_to_kpc}else{gas$Coordinates[2,]*.cm_to_kpc},
+                                      "z"  = if(one_p_flag){gas$Coordinates[3]*.cm_to_kpc}else{gas$Coordinates[3,]*.cm_to_kpc},
+                                      "vx"  = if(one_p_flag){gas$Velocity[1]*.cms_to_kms}else{gas$Velocity[1,]*.cms_to_kms}, # Velocities in km/s
+                                      "vy"  = if(one_p_flag){gas$Velocity[2]*.cms_to_kms}else{gas$Velocity[2,]*.cms_to_kms},
+                                      "vz"  = if(one_p_flag){gas$Velocity[3]*.cms_to_kms}else{gas$Velocity[3,]*.cms_to_kms},
+                                      "Mass" = gas$Mass*.g_to_msol, # Mass in solar masses
+                                      "SFR" = gas$StarFormationRate*(.g_to_msol/.s_to_yr), #SFR in Msol/yr
+                                      "Density" = gas$Density*.gcm3_to_msolkpc3, # Density in Msol/kpc^3
+                                      "Temperature" = gas$Temperature,
+                                      "SmoothingLength" = gas$SmoothingLength*.cm_to_kpc, # Smoothing length in kpc
+                                      "ThermalDispersion" = sqrt((gas$InternalEnergy*.cms_to_kms)*(.adiabatic_index - 1)),
+                                      "Metallicity" = gas$Metallicity,
+                                      "Hydrogen" = gas$`ElementAbundance/Hydrogen`,
+                                      "Oxygen" = gas$`ElementAbundance/Oxygen`)
+
+    gas_part$ThermalDispersion[gas_part$Temperature <= 1e4] = 11
+
+    remove(gas); remove(PT0_attr)
+
+  } else {gas_part=NULL}
+
+  if ("PartType4" %in% groups){
+    PT4_attr = hdf5r::list.datasets(data[["PartType4"]])
+
+    expected_names_stars = c("Coordinates", "InitialMass", "Mass", "ParticleIDs",
+                             "Metallicity", "StellarFormationTime", "Velocity")
+    PT4_attr = PT4_attr[which(PT4_attr %in% expected_names_stars)] # trim list to only read in necessary data sets
+
+    n_star_prop = length(PT4_attr)
+    stars = vector("list", n_star_prop)
+    names(stars) = PT4_attr
+
+    for (i in 1:n_star_prop){
+      aexp = hdf5r::h5attr(data[[paste0("PartType4/",PT4_attr[i])]], "aexp-scale-exponent")
+      hexp = hdf5r::h5attr(data[[paste0("PartType4/",PT4_attr[i])]], "h-scale-exponent")
+      cgs  = hdf5r::h5attr(data[[paste0("PartType4/",PT4_attr[i])]], "CGSConversionFactor")
+      stars[[i]] =
+        hdf5r::readDataSet(data[[paste0("PartType4/",PT4_attr[i])]]) * head$Time^(aexp) * head$HubbleParam^(hexp) * cgs
+    }
+
+    stars = .check_names(stars, type="Colibre")
+
+    one_p_flag = FALSE
+    if (is.null(dim(stars$Coordinates))){one_p_flag = TRUE}
+
+    star_part = data.table::data.table("ID" = stars$ParticleIDs,
+                                       "x"  = if(one_p_flag){stars$Coordinates[1]*.cm_to_kpc}else{stars$Coordinates[1,]*.cm_to_kpc}, # Coordinates in kpc
+                                       "y"  = if(one_p_flag){stars$Coordinates[2]*.cm_to_kpc}else{stars$Coordinates[2,]*.cm_to_kpc},
+                                       "z"  = if(one_p_flag){stars$Coordinates[3]*.cm_to_kpc}else{stars$Coordinates[3,]*.cm_to_kpc},
+                                       "vx"  = if(one_p_flag){stars$Velocity[1]*.cms_to_kms}else{stars$Velocity[1,]*.cms_to_kms}, # Velocities in km/s
+                                       "vy"  = if(one_p_flag){stars$Velocity[2]*.cms_to_kms}else{stars$Velocity[2,]*.cms_to_kms},
+                                       "vz"  = if(one_p_flag){stars$Velocity[3]*.cms_to_kms}else{stars$Velocity[3,]*.cms_to_kms},
+                                       "Mass" = stars$Mass*.g_to_msol) # Mass in solar masses
+
+    ssp = data.table::data.table("Initial_Mass" = stars$InitialMass*.g_to_msol,
+                                 "Age" = as.numeric(.SFTtoAge(a=stars$StellarFormationTime,
+                                                              cores=cores, H0=head$H0,
+                                                              OmegaM=head$OmegaM,
+                                                              OmegaL=head$OmegaL,
+                                                              OmegaR=head$OmegaR)),
+                                 "Metallicity" = stars$Metallicity)
+
+    remove(stars); remove(PT4_attr)
+
+  } else {star_part=NULL; ssp=NULL}
+
+  return(list(star_part=star_part, gas_part=gas_part, head=head, ssp=ssp))
+
+}
+
+
+
 
 # Function to check existing names in a data set and convert if necessary
 .check_names = function(particle_list, type){

--- a/R/read_files.R
+++ b/R/read_files.R
@@ -999,9 +999,20 @@
   head$Type = paste0("Generic read - ", head$RunLabel)
   head$H0 = head$HubbleParam * 100
   head$Time = 1/(1+head$Redshift)
-  names(head)[names(head) == "Omega_m"] = "OmegaM"
-  names(head)[names(head) == "Omega_lambda"] = "OmegaL"
+  names(head)[names(head) == "Omega_m" | names(head) == "Omega0"] = "OmegaM"
+  names(head)[names(head) == "Omega_lambda" | names(head) == "OmegaLambda"] = "OmegaL"
   names(head)[names(head) == "Omega_r"] = "OmegaR"
+
+  if (all(is.null(head$OmegaM), is.null(head$OmegaL), is.null(head$OmegaR))){
+    warning("Warning! Missing Omega parameters from header.\n
+    Using default Planck 2018 values OmegaM = 0.301, OmegaL = 0.699, OmegaR = 8.985075e-05.\n
+            See https://kateharborne.github.io/SimSpin/examples/generating_hdf5.html#header for more details.")
+    head$OmegaM = 0.301
+    head$OmegaL = 0.699
+    head$OmegaR = 8.985075e-05
+  } else if (is.null(head$OmegaR) & !is.null(head$OmegaM) & !is.null(head$OmegaL)){
+    head$OmegaR = 0
+  }
 
   groups = hdf5r::list.groups(data) # What particle data is present?
   groups = groups[stringr::str_detect(groups, "PartType")] # Pick out PartTypeX groups

--- a/R/read_files.R
+++ b/R/read_files.R
@@ -996,6 +996,7 @@
 
   head$Type = paste0("Generic read - ", head$RunLabel)
   head$H0 = head$HubbleParam * 100
+  head$Time = 1/(1+head$Redshift)
   names(head)[names(head) == "Omega_m"] = "OmegaM"
   names(head)[names(head) == "Omega_lambda"] = "OmegaL"
   names(head)[names(head) == "Omega_r"] = "OmegaR"
@@ -1021,8 +1022,6 @@
     }
 
     PT0_attr = PT0_attr[which(PT0_attr %in% expected_names_gas)] # trim list to only read in necessary data sets
-
-
 
     n_gas_prop = length(PT0_attr)
     gas = vector("list", n_gas_prop)

--- a/R/read_files.R
+++ b/R/read_files.R
@@ -1101,8 +1101,6 @@
 }
 
 
-
-
 # Function to check existing names in a data set and convert if necessary
 .check_names = function(particle_list, type){
 

--- a/R/read_files.R
+++ b/R/read_files.R
@@ -171,6 +171,7 @@
       magneticum = F
       horizonagn = F
       colibre = F
+      generic = F
       if(stringr::str_detect(stringr::str_to_lower(head$SimulationName), "tng")){illustristng = T}else{illustristng = F}
     } else {
       gadget2 = F

--- a/R/read_files.R
+++ b/R/read_files.R
@@ -170,8 +170,7 @@
       if(stringr::str_detect(stringr::str_to_lower(head$RunLabel), "magneticum")){magneticum = T}else{magneticum=F}
       if(stringr::str_detect(stringr::str_to_lower(head$RunLabel), "horizon")){horizonagn = T}else{horizonagn = F}
       if(stringr::str_detect(stringr::str_to_lower(head$RunLabel), "colibre")){colibre = T}else{colibre = F}
-    }
-
+      if(!all(eagle, illustristng, magneticum, horizonagn, colibre, gadget2)){generic=T}else{generic = F}
   }
 
   # Read particle data differently depending on the simulation being read in...
@@ -181,6 +180,7 @@
   if (horizonagn){output = .horizonagn_read_hdf5(data, head, cores)}
   if (illustristng){output = .illustristng_read_hdf5(data, head, cores)}
   if (colibre){output = .colibre_read_hdf5(data, head, cores)}
+  if (generic){output = .generic_read_hdf5(data, head, cores)}
 
   hdf5r::h5close(data)
 

--- a/R/read_files.R
+++ b/R/read_files.R
@@ -1091,6 +1091,11 @@
 
     stars = .check_names(stars, type="Generic")
 
+    # catch for stars with formation time below machine precision
+    if (any(stars$StellarFormationTime < .Machine$double.xmin)){
+      stars$StellarFormationTime[which(stars$StellarFormationTime < .Machine$double.xmin)] = min(stars$StellarFormationTime[which(stars$StellarFormationTime > .Machine$double.xmin)], na.rm=T)
+    }
+
     one_p_flag = FALSE
     if (is.null(dim(stars$Coordinates))){one_p_flag = TRUE}
 

--- a/R/read_files.R
+++ b/R/read_files.R
@@ -171,6 +171,7 @@
       if(stringr::str_detect(stringr::str_to_lower(head$RunLabel), "horizon")){horizonagn = T}else{horizonagn = F}
       if(stringr::str_detect(stringr::str_to_lower(head$RunLabel), "colibre")){colibre = T}else{colibre = F}
       if(!all(eagle, illustristng, magneticum, horizonagn, colibre, gadget2)){generic=T}else{generic = F}
+    }
   }
 
   # Read particle data differently depending on the simulation being read in...
@@ -1261,3 +1262,4 @@
   }
   return(output)
 }
+

--- a/R/read_files.R
+++ b/R/read_files.R
@@ -1036,7 +1036,7 @@
         hdf5r::readDataSet(data[[paste0("PartType0/",PT0_attr[i])]]) * head$Time^(aexp) * head$HubbleParam^(hexp) * cgs
     }
 
-    gas = .check_names(gas, type="Colibre")
+    gas = .check_names(gas, type="Generic")
 
     colibre_gas_names = c("SmoothingLength", "Temperature", "InternalEnergy")
     if (!all(colibre_gas_names %in% names(gas))){
@@ -1090,7 +1090,7 @@
         hdf5r::readDataSet(data[[paste0("PartType4/",PT4_attr[i])]]) * head$Time^(aexp) * head$HubbleParam^(hexp) * cgs
     }
 
-    stars = .check_names(stars, type="Colibre")
+    stars = .check_names(stars, type="Generic")
 
     one_p_flag = FALSE
     if (is.null(dim(stars$Coordinates))){one_p_flag = TRUE}
@@ -1142,7 +1142,7 @@
     names(particle_list) <- current_names
   }
 
-  if ("Hydrogen" %in% current_names & stringr::str_detect(type, "Generic")){
+  if ("Hydrogen" %in% current_names & type == "Generic"){
     current_names[which(current_names == "Hydrogen")] <- "ElementAbundance/Hydrogen"
     names(particle_list) <- current_names
   }
@@ -1158,7 +1158,7 @@
     names(particle_list) <- current_names
   }
 
-  if ("Oxygen" %in% current_names & stringr::str_detect(type, "Generic")){
+  if ("Oxygen" %in% current_names & type == "Generic"){
     current_names[which(current_names == "Oxygen")] <- "ElementAbundance/Oxygen"
     names(particle_list) <- current_names
   }

--- a/tests/testthat/test_make_simspin_file.R
+++ b/tests/testthat/test_make_simspin_file.R
@@ -31,6 +31,15 @@ generic_data[["PartType0/Metallicity"]] = generic_data[["PartType0/SmoothedMetal
 generic_data[["PartType4/Metallicity"]] = generic_data[["PartType4/SmoothedMetallicity"]]
 hdf5r::h5close(generic_data)
 
+file.copy(from = paste0(temp_loc, "/SimSpin_example_generic.hdf5"),
+          to = paste0(temp_loc, "/SimSpin_example_generic_metals.hdf5"))
+ss_generic_metals = paste0(temp_loc, "/SimSpin_example_generic_metals.hdf5")
+generic_metals_data = hdf5r::h5file(ss_generic_metals, mode="r+")
+generic_metals_data[["PartType0/Oxygen"]] = generic_metals_data[["PartType0/ElementAbundance/Oxygen"]]
+generic_metals_data[["PartType0/Hydrogen"]] = generic_metals_data[["PartType0/ElementAbundance/Hydrogen"]]
+generic_metals_data[["PartType0/Carbon"]] = generic_metals_data[["PartType0/ElementAbundance/Carbon"]]
+hdf5r::h5close(generic_metals_data)
+
 
 # Test that the function runs successfully without error
 test_that("Initial run of each simulation type - Gadget.", {
@@ -114,6 +123,8 @@ test_that("Initial run of each simulation type - Colibre", {
 test_that("Initial run of each simulation type - Generic", {
   # Modify the EAGLE file header to trigger processing via the generic route
   expect_null(make_simspin_file(ss_generic, output = paste(temp_loc, "/generic_test", sep="")))
+
+  expect_null(make_simspin_file(ss_generic_metals, output = paste(temp_loc, "/generic_metals_test", sep="")))
 
   generic = readRDS(paste(temp_loc, "/generic_test", sep=""))
   expect_length(generic, ss_file_length)
@@ -425,7 +436,8 @@ test_that("Temperature does not go outside a reasonable range",{
 unlink(c(paste(temp_loc, "/gadget_test", sep=""), paste(temp_loc, "/hdf5_test", sep=""),
          paste(temp_loc, "/eagle_test", sep=""), paste(temp_loc, "/magneticum_test", sep=""),
          paste(temp_loc, "/horizon_test", sep=""), paste(temp_loc, "/illustris_test", sep=""),
-         paste(temp_loc, "/colibre_test", sep="")))
+         paste(temp_loc, "/colibre_test", sep=""), paste(temp_loc, "/generic_test", sep=""),
+         paste(temp_loc, "/generic_metals_test", sep="")))
 
 # Testing that the centre parameter works as expected ------------
 test_that("Objects are centered correctly based on the specified central coordinates", {
@@ -924,4 +936,4 @@ test_that("No errors when other HDF5 files input only have 11 gas particles - EA
 
 })
 
-unlink(c(ss_generic, temp_loc))
+unlink(c(ss_generic, ss_generic_metals, temp_loc))

--- a/tests/testthat/test_make_simspin_file.R
+++ b/tests/testthat/test_make_simspin_file.R
@@ -20,6 +20,18 @@ built_cube_size = 5
 
 temp_loc = tempdir()
 
+# Modifying EAGLE file to make an additional generic file
+file.copy(from = system.file("extdata", "SimSpin_example_EAGLE.hdf5", package = "SimSpin"),
+          to = paste0(temp_loc, "/SimSpin_example_generic.hdf5"))
+ss_generic = paste0(temp_loc, "/SimSpin_example_generic.hdf5")
+generic_data = hdf5r::h5file(ss_generic, mode="r+")
+hdf5r::h5attr(generic_data[["Header"]], "RunLabel") = "Random"
+generic_data[["PartType0/ElementAbundance"]] = generic_data[["PartType0/SmoothedElementAbundance"]]
+generic_data[["PartType0/Metallicity"]] = generic_data[["PartType0/SmoothedMetallicity"]]
+generic_data[["PartType4/Metallicity"]] = generic_data[["PartType4/SmoothedMetallicity"]]
+hdf5r::h5close(generic_data)
+
+
 # Test that the function runs successfully without error
 test_that("Initial run of each simulation type - Gadget.", {
   expect_null(make_simspin_file(ss_gadget, template = "BC03hr", output = paste(temp_loc, "/gadget_test", sep="")))
@@ -99,6 +111,19 @@ test_that("Initial run of each simulation type - Colibre", {
 
 })
 
+test_that("Initial run of each simulation type - Generic", {
+  # Modify the EAGLE file header to trigger processing via the generic route
+  expect_null(make_simspin_file(ss_generic, output = paste(temp_loc, "/generic_test", sep="")))
+
+  generic = readRDS(paste(temp_loc, "/generic_test", sep=""))
+  expect_length(generic, ss_file_length)
+  expect_true(generic$header$Type == "Generic read - Random")
+  expect_true(length(generic$gas_part) == 16)
+  expect_true(nrow(generic$spectral_weights) == 8)
+  expect_false(any(is.na(generic$gas_part$ThermalDispersion)))
+  expect_true(all(generic$gas_part$ThermalDispersion[generic$gas_part$Temperature < 1e4] == 11))
+})
+
 # Test that the function fails when the file already exists
 test_that("Error when output file already exists and overwrite = F - Gadget",{
   expect_error(make_simspin_file(ss_gadget, output = paste(temp_loc, "/gadget_test", sep="")))
@@ -126,6 +151,10 @@ test_that("Error when output file already exists and overwrite = F - IllustrisTN
 
 test_that("Error when output file already exists and overwrite = F - Colibre",{
   expect_error(make_simspin_file(ss_colibre, output = paste(temp_loc, "/colibre_test", sep="")))
+})
+
+test_that("Error when output file already exists and overwrite = F - Generic",{
+  expect_error(make_simspin_file(ss_generic, output = paste(temp_loc, "/generic_test", sep="")))
 })
 
 # Test that function can output to environment
@@ -157,6 +186,7 @@ test_that("Values are successfully associated with variables", {
   hdf5      = readRDS(paste(temp_loc, "/hdf5_test", sep=""))
   eagle     = readRDS(paste(temp_loc, "/eagle_test", sep=""))
   illustris = readRDS(paste(temp_loc, "/illustris_test", sep=""))
+  generic   = readRDS(paste(temp_loc, "/generic_test", sep=""))
 
   expect_true(all(!is.na(gadget$star_part$x)))
   expect_true(all(!is.na(gadget$star_part$y)))
@@ -232,6 +262,30 @@ test_that("Values are successfully associated with variables", {
   expect_true(all(!is.na(illustris$gas_part$Temperature)))
   expect_true(all(!is.na(illustris$gas_part$Metallicity)))
   # SmoothingLength, Carbon/Hydrogen/Oxygen?
+
+  expect_true(all(!is.na(generic$star_part$x)))
+  expect_true(all(!is.na(generic$star_part$y)))
+  expect_true(all(!is.na(generic$star_part$z)))
+  expect_true(all(!is.na(generic$star_part$vx)))
+  expect_true(all(!is.na(generic$star_part$vy)))
+  expect_true(all(!is.na(generic$star_part$vz)))
+  expect_true(all(!is.na(generic$star_part$Mass)))
+  expect_true(all(!is.na(generic$star_part$sed_id)))
+  expect_true(all(!is.na(generic$star_part$Metallicity)))
+  expect_true(all(!is.na(generic$star_part$Age)))
+  expect_true(all(!is.na(generic$star_part$Initial_Mass)))
+
+  expect_true(all(!is.na(generic$gas_part$x)))
+  expect_true(all(!is.na(generic$gas_part$y)))
+  expect_true(all(!is.na(generic$gas_part$z)))
+  expect_true(all(!is.na(generic$gas_part$vx)))
+  expect_true(all(!is.na(generic$gas_part$vy)))
+  expect_true(all(!is.na(generic$gas_part$vz)))
+  expect_true(all(!is.na(generic$gas_part$Mass)))
+  expect_true(all(!is.na(generic$gas_part$SFR)))
+  expect_true(all(!is.na(generic$gas_part$Density)))
+  expect_true(all(!is.na(generic$gas_part$Temperature)))
+  expect_true(all(!is.na(generic$gas_part$Metallicity)))
 })
 
 # Testing the sph_spawn functionality ----
@@ -869,3 +923,5 @@ test_that("No errors when other HDF5 files input only have 11 gas particles - EA
   unlink(paste0(temp_loc, "/SimSpin_example_eagle_copy.hdf5"))
 
 })
+
+unlink(c(ss_generic, temp_loc))


### PR DESCRIPTION
Addressing issue #133 - when a generic HDF5 file is written according to the formats outlined in the documentation, the code should behave as expected. In this case, gas will be assumed to follow a Wendland 2 kernel profile for oversampling purposes. Tests have been added to ensure inputs with a "RunLabel" in the header that is not of a supported simulation will be routed through the "generic" processing pathway. 

Will close Issue #133 once documentation has further been updated to reflect this, but merging this into main. 